### PR TITLE
Fixed typo: 'swtich' in irq.c

### DIFF
--- a/arch/sh/boards/mach-landisk/irq.c
+++ b/arch/sh/boards/mach-landisk/irq.c
@@ -29,8 +29,8 @@ enum {
 	PCI_INTD, /* PCI int D */
 	ATA,	  /* ATA */
 	FATA,	  /* CF */
-	POWER,	  /* Power swtich */
-	BUTTON,	  /* Button swtich */
+	POWER,	  /* Power switch */
+	BUTTON,	  /* Button switch */
 };
 
 /* Vectors for LANDISK */


### PR DESCRIPTION
Note that the word 'swtich' is wrong,
so that 'swtich' should been replaced with 'switch'.