### PR TITLE
cgroup: blkio: adjust block io bps limit by weight

### DIFF
--- a/block/blk-sysfs.c
+++ b/block/blk-sysfs.c
@@ -364,6 +364,17 @@ queue_rq_affinity_store(struct request_queue *q, const char *page, size_t count)
 	return ret;
 }
 
+static ssize_t queue_avg_perf_show(struct request_queue *q, char *page)
+{
+	return sprintf(page, "%llu\n",
+		       (unsigned long long)q->disk_bw * 512);
+}
+
+static struct queue_sysfs_entry queue_avg_perf_entry = {
+	.attr = {.name = "average_perf", .mode = S_IRUGO },
+	.show = queue_avg_perf_show,
+};
+
 static ssize_t queue_poll_delay_show(struct request_queue *q, char *page)
 {
 	int val;
@@ -688,6 +699,7 @@ static struct queue_sysfs_entry throtl_sample_time_entry = {
 #endif
 
 static struct attribute *default_attrs[] = {
+	&queue_avg_perf_entry.attr,
 	&queue_requests_entry.attr,
 	&queue_ra_entry.attr,
 	&queue_max_hw_sectors_entry.attr,

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -617,6 +617,14 @@ struct request_queue {
 
 #define BLK_MAX_WRITE_HINTS	5
 	u64			write_hints[BLK_MAX_WRITE_HINTS];
+
+	/* disk computed throughput */
+	unsigned long		disk_bw;
+	/* next time to calculate disk throughput */
+	unsigned long		next_ck_time;
+	unsigned long		last_sectors;
+	u64			io_ticks_ns;
+
 };
 
 #define QUEUE_FLAG_QUEUED	0	/* uses generic tag queueing */

--- a/include/linux/genhd.h
+++ b/include/linux/genhd.h
@@ -89,6 +89,7 @@ struct disk_stats {
 	unsigned long ticks[2];
 	unsigned long io_ticks;
 	unsigned long time_in_queue;
+	u64 io_ticks_ns;
 };
 
 #define PARTITION_META_INFO_VOLNAMELTH	64
@@ -122,6 +123,7 @@ struct hd_struct {
 	int make_it_fail;
 #endif
 	unsigned long stamp;
+	u64 stamp_ns;
 	atomic_t in_flight[2];
 #ifdef	CONFIG_SMP
 	struct disk_stats __percpu *dkstats;


### PR DESCRIPTION
Kernel now supports cgroup bps and iops hard limit by io-throttling.
But that's not a scalable way, because block devices' bandwith is
always changing over time.

This patch dynamically adjusts bps limit of each blkio cgroup according
to its pre-set weight. Additionally, if a process has not issued any io
request during a time window, its weight will be shared by other processes
until its next io request.

Signed-off-by: Lei Chen <lennychen@tencent.com>