### PR TITLE
memcg: add scheduling point while showing memcg usage

### DIFF
--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -335,6 +335,7 @@ extern int sysctl_min_epoll_wait_time;
 extern int sysctl_clocksource_switch_unstable_cs;
 extern int sysctl_clocksource_unstable_cnt;
 extern unsigned int sysctl_memcg_stat_show_subtree;
+extern unsigned int sysctl_memcg_usage_show_sched;
 
 unsigned int sysctl_cgroup_stats_isolated = 0;
 
@@ -372,7 +373,13 @@ static struct ctl_table kern_table[] = {
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec,
 	},
-
+	{
+		.procname	= "memcg_usage_show_sched",
+		.data		= &sysctl_memcg_usage_show_sched,
+		.maxlen		= sizeof(unsigned int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec,
+	},
 #ifdef CONFIG_PID_NS
 	{
 		.procname       = "watch_host_pid",


### PR DESCRIPTION
Without preemption, if syscall excutes too long it will significantly
affect performance of other important processes. So add a shceduling
point when showing root memcg usage.

Signed-off-by: yongduan <yongduan@tencent.com>
Signed-off-by: charliecgxu <charliecgxu@tencent.com>