### PR TITLE
fix regression bug cause by ipvs_mode=2 patch

### DIFF
--- a/net/netfilter/ipvs/ip_vs_xmit.c
+++ b/net/netfilter/ipvs/ip_vs_xmit.c
@@ -782,9 +782,10 @@ ip_vs_nat_xmit(struct sk_buff *skb, struct ip_vs_conn *cp,
 	/* originally, this was set in ip_route_input_slow
 	 * In bpf mode, this is not useful since local rs is not allowed
 	 */
-	was_input = rt_is_input_route(skb_rtable(skb));
 	if (ipvs_mode == IPVS_BPF_MODE)
 		was_input = 1;
+	else
+		was_input = rt_is_input_route(skb_rtable(skb));
 	local = __ip_vs_get_out_rt(cp->ipvs, cp->af, skb, cp->dest, cp->daddr.ip,
 				   IP_VS_RT_MODE_LOCAL |
 				   IP_VS_RT_MODE_NON_LOCAL |


### PR DESCRIPTION
reason: in ipvs_mode ==1 , skb_rtable is ip_vs_nat_xmit is null.
Test case: test bpf mode nodeport ok!

Signed-off-by: jianmingfan <jianmingfan@tencent.com>