### PR TITLE
Rps using pvipi

### DIFF
--- a/include/linux/smp.h
+++ b/include/linux/smp.h
@@ -94,6 +94,16 @@ extern int __cpu_up(unsigned int cpunum, struct task_struct *tidle);
  */
 extern void smp_cpus_done(unsigned int max_cpus);
 
+#define smp_call_function_many_async_begin(cpumask) \
+    preempt_disable();
+
+int smp_call_function_many_async(int cpu, call_single_data_t *csd, struct cpumask *mask);
+
+#define smp_call_function_many_async_end(cpumask) \
+    arch_send_call_function_ipi_mask(cpumask); \
+    preempt_enable();
+
+
 /*
  * Call a function on all other processors
  */
@@ -135,6 +145,10 @@ static inline int get_boot_cpu_id(void)
 #else /* !SMP */
 
 static inline void smp_send_stop(void) { }
+
+#define smp_call_function_many_async_begin(cpumask)
+#define smp_call_function_many_async(cpu, csd, mask) smp_call_function_single_async(cpu, csd)
+#define smp_call_function_many_async_end(cpumask)
 
 /*
  *	These macros fold the SMP functionality into a single CPU system

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -139,7 +139,7 @@ static DEFINE_PER_CPU_SHARED_ALIGNED(call_single_data_t, csd_data);
  * ->func, ->info, and ->flags set.
  */
 static int generic_exec_single(int cpu, call_single_data_t *csd,
-			       smp_call_func_t func, void *info)
+			       smp_call_func_t func, void *info, bool need_ipi, struct cpumask *mask)
 {
 	if (cpu == smp_processor_id()) {
 		unsigned long flags;
@@ -176,7 +176,8 @@ static int generic_exec_single(int cpu, call_single_data_t *csd,
 	 * equipped to do the right thing...
 	 */
 	if (llist_add(&csd->llist, &per_cpu(call_single_queue, cpu)))
-		arch_send_call_function_single_ipi(cpu);
+		if (need_ipi) arch_send_call_function_single_ipi(cpu);
+		else __cpumask_set_cpu(cpu, mask);
 
 	return 0;
 }
@@ -296,7 +297,7 @@ int smp_call_function_single(int cpu, smp_call_func_t func, void *info,
 		csd_lock(csd);
 	}
 
-	err = generic_exec_single(cpu, csd, func, info);
+	err = generic_exec_single(cpu, csd, func, info, true, NULL);
 
 	if (wait)
 		csd_lock_wait(csd);
@@ -336,12 +337,49 @@ int smp_call_function_single_async(int cpu, call_single_data_t *csd)
 	csd->flags = CSD_FLAG_LOCK;
 	smp_wmb();
 
-	err = generic_exec_single(cpu, csd, csd->func, csd->info);
+	err = generic_exec_single(cpu, csd, csd->func, csd->info, true, NULL);
 	preempt_enable();
 
 	return err;
 }
 EXPORT_SYMBOL_GPL(smp_call_function_single_async);
+
+/**
+ * smp_call_function_many_async(): Run an asynchronous function on a
+ * 			         specific CPU.
+ * @cpu: The CPU to run on.
+ * @csd: Pre-allocated and setup data structure
+ *
+ * Like smp_call_function_single(), but the call is asynchonous and
+ * can thus be done from contexts with disabled interrupts.
+ *
+ * The caller passes his own pre-allocated data structure
+ * (ie: embedded in an object) and is responsible for synchronizing it
+ * such that the IPIs performed on the @csd are strictly serialized.
+ *
+ * NOTE: Be careful, there is unfortunately no current debugging facility to
+ * validate the correctness of this serialization.
+ */
+int smp_call_function_many_async(int cpu, call_single_data_t *csd, struct cpumask *mask)
+{
+	int err = 0;
+
+	preempt_disable();
+
+	/* We could deadlock if we have to wait here with interrupts disabled! */
+	if (WARN_ON_ONCE(csd->flags & CSD_FLAG_LOCK))
+		csd_lock_wait(csd);
+
+	csd->flags = CSD_FLAG_LOCK;
+	smp_wmb();
+
+	err = generic_exec_single(cpu, csd, csd->func, csd->info, false, mask);
+	preempt_enable();
+
+	return err;
+}
+EXPORT_SYMBOL_GPL(smp_call_function_many_async);
+
 
 /*
  * smp_call_function_any - Run a function on any of the given cpus

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -340,6 +340,9 @@ extern int min_softirq_accel_mask;
 extern int max_softirq_accel_mask;
 extern unsigned int sysctl_memcg_stat_show_subtree;
 extern unsigned int sysctl_memcg_usage_show_sched;
+#ifdef CONFIG_RPS
+extern unsigned int sysctl_rps_using_pvipi;
+#endif
 
 unsigned int sysctl_cgroup_stats_isolated = 0;
 
@@ -400,6 +403,15 @@ static struct ctl_table kern_table[] = {
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec,
 	},
+#ifdef CONFIG_RPS
+	{
+		.procname	= "rps_using_pvipi",
+		.data		= &sysctl_rps_using_pvipi,
+		.maxlen		= sizeof(unsigned int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec,
+	},
+#endif
 #ifdef CONFIG_PID_NS
 	{
 		.procname       = "watch_host_pid",


### PR DESCRIPTION
网络rps发送IPI中断给其他核，是一个一个发送IPI中断的，在虚拟化场景下每发送一个IPI都会导致一次退出。
虚拟化场景使用pvipi来优化退出次数，通过hypercall可以只借助一次退出发送多个IPI中断。
目前tkernel3已支持该功能，但网络rps发送IPI中断本身无法利用该特性，网络性能在虚拟化场景会降低。

rps using pvipi 测试结果
测试环境, 32核心64G内存, virtio-net 8 queues
rss 中断绑定在24-31核, 观察31核vmexit次数.
1. 1000000pps
100 iperf instances, 10000pps per instance.
disable rps_using_pvipi  68077 vmexit/s
enable  rps_using_pvipi  21138 vmexit/s

2. 2000000pps
1000 iperf instances, 2000pps per instance.
disable rps_using_pvipi  40879 vmexit/s
enable  rps_using_pvipi  9195  vmexit/s

3. 2000000pps
2000 iperf instances, 1000pps per instance.
disable rps_using_pvipi  24746 vmexit/s
enable  rps_using_pvipi  7292  vmexit/s