### PR TITLE
bugfix: since a01a9445c00ec, ipvs sysctl have been missing sysctl swi…

### DIFF
--- a/net/netfilter/ipvs/ip_vs_ctl.c
+++ b/net/netfilter/ipvs/ip_vs_ctl.c
@@ -1886,6 +1886,12 @@ static struct ctl_table vs_vars[] = {
 		.proc_handler	= proc_dointvec,
 	},
 	{
+		.procname	= "conn_reuse_old_conntrack",
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec,
+	},
+	{
 		.procname	= "schedule_icmp",
 		.maxlen		= sizeof(int),
 		.mode		= 0644,


### PR DESCRIPTION
…tch 'conn_reuse_old_conntrack', that lead a switch dislocation

Signed-off-by: YangYuxi <yx.atom1@gmail.com>