### PR TITLE
net: rps using pvipi

### DIFF
--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -187,6 +187,10 @@ extern int unaligned_dump_stack;
 extern int no_unaligned_warning;
 #endif
 
+#ifdef CONFIG_RPS
+extern unsigned int sysctl_rps_using_pvipi;
+#endif
+
 #ifdef CONFIG_PROC_SYSCTL
 
 /**
@@ -409,6 +413,17 @@ static struct ctl_table kern_table[] = {
 		.extra1		= &min_softirq_accel_mask,
 		.extra2		= &max_softirq_accel_mask,
 	},
+#ifdef CONFIG_RPS
+	{
+		.procname	= "rps_using_pvipi",
+		.data		= &sysctl_rps_using_pvipi,
+		.maxlen		= sizeof(unsigned int),
+		.mode		= 0644,
+		.proc_handler   = proc_dointvec_minmax,
+		.extra1         = SYSCTL_ZERO,
+		.extra2         = SYSCTL_ONE,
+	},
+#endif
 #ifdef CONFIG_PID_NS
 	{
 		.procname	= "watch_host_pid",

--- a/net/core/dev.c
+++ b/net/core/dev.c
@@ -4081,7 +4081,7 @@ EXPORT_SYMBOL(rps_may_expire_flow);
 /* Called from hardirq (IPI) context */
 static void rps_trigger_softirq(void *data)
 {
-	struct softnet_data *sd = data;
+	struct softnet_data *sd = &per_cpu(softnet_data, smp_processor_id());
 
 	____napi_schedule(sd, &sd->backlog);
 	sd->received_rps++;
@@ -5803,16 +5803,34 @@ __sum16 __skb_gro_checksum_complete(struct sk_buff *skb)
 }
 EXPORT_SYMBOL(__skb_gro_checksum_complete);
 
+#ifdef CONFIG_RPS
+static DEFINE_PER_CPU_SHARED_ALIGNED(struct cpumask, ipi_mask);
+unsigned int sysctl_rps_using_pvipi = 1;
+#endif
+
 static void net_rps_send_ipi(struct softnet_data *remsd)
 {
 #ifdef CONFIG_RPS
-	while (remsd) {
-		struct softnet_data *next = remsd->rps_ipi_next;
+	if (sysctl_rps_using_pvipi) {
+		struct cpumask *tmpmask = this_cpu_ptr(&ipi_mask);
+		cpumask_clear(tmpmask);
+		smp_call_function_many_async_begin(tmpmask);
+		while (remsd) {
+			struct softnet_data *next = remsd->rps_ipi_next;
 
-		if (cpu_online(remsd->cpu))
-			smp_call_function_single_async(remsd->cpu, &remsd->csd);
-		remsd = next;
-	}
+			if (cpu_online(remsd->cpu))
+				smp_call_function_many_async(remsd->cpu, &remsd->csd, tmpmask);
+			remsd = next;
+		}
+		smp_call_function_many_async_end(tmpmask);
+	} else
+		while (remsd) {
+			struct softnet_data *next = remsd->rps_ipi_next;
+
+			if (cpu_online(remsd->cpu))
+				smp_call_function_single_async(remsd->cpu, &remsd->csd);
+			remsd = next;
+		}
 #endif
 }
 


### PR DESCRIPTION
In the virtualization scenario, you can use pvipi to optimize the sending of
IPI interrupts and reduce the number of vmexit.

rps_using_pvipi test
Test guest: 32 core, 64G memory, virtio-net 8 queues, rss interrupt is bound
to 24-31 core. Observe the number of vmexit of 31 cores.

1. 1000000pps
100 iperf instances, 10000pps per instance.
disable rps_using_pvipi  68077 vmexit/s
enable  rps_using_pvipi  21138 vmexit/s

2. 2000000pps
1000 iperf instances, 2000pps per instance.
disable rps_using_pvipi  40879 vmexit/s
enable  rps_using_pvipi  9195  vmexit/s

3. 2000000pps
2000 iperf instances, 1000pps per instance.
disable rps_using_pvipi  24746 vmexit/s
enable  rps_using_pvipi  7292  vmexit/s

Enabling rps_using_pvipi can greatly reduce the number of vmexit.

Signed-off-by: yongduan <yongduan@tencent.com>
Reviewed-by: Jiang Biao <benbjiang@tencent.com>