### PR TITLE
generate-rpms: modify the name of the kernel tag for x86 and arm64

### DIFF
--- a/package/arm/generate-rpms.sh
+++ b/package/arm/generate-rpms.sh
@@ -78,12 +78,12 @@ get_tlinux_name()
 		exit 1
 	fi
 
-        if [[ $raw_tagged_name != public-arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for public-arm64"
+        if [[ $raw_tagged_name != arm64-* ]]; then
+                echo "$raw_tagged_name not valid tag name for arm64"
                 exit 1
 	fi
 
-	tagged_name=${raw_tagged_name#public-arm64-}
+	tagged_name=${raw_tagged_name#arm64-}
 
 	echo "${tagged_name}" | grep 'kvm_guest'
 	if [ $? -eq 0 ]; then

--- a/package/arm/repackage/generate-rpms.sh
+++ b/package/arm/repackage/generate-rpms.sh
@@ -58,12 +58,12 @@ get_kernel_version()
 	local tagged_name
 	raw_tagged_name=$tag_name
 
-	if [[ $raw_tagged_name != public-arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for public-arm64"
+	if [[ $raw_tagged_name != arm64-* ]]; then
+                echo "$raw_tagged_name not valid tag name for arm64"
                 exit 1
         fi  
 
-	tagged_name=${raw_tagged_name#public-arm64-}
+	tagged_name=${raw_tagged_name#arm64-}
 
 	kernel_version=`echo $tagged_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
@@ -84,12 +84,12 @@ get_tlinux_name()
 		exit 1
 	fi
 
-	if [[ $raw_tagged_name != public-arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for public-arm64"
+	if [[ $raw_tagged_name != arm64-* ]]; then
+                echo "$raw_tagged_name not valid tag name for arm64"
                 exit 1
         fi  
 
-	tagged_name=${raw_tagged_name#public-arm64-}
+	tagged_name=${raw_tagged_name#arm64-}
 
 
 	echo "${tagged_name}" | grep 'kvm_guest'

--- a/package/default/generate-rpms.sh
+++ b/package/default/generate-rpms.sh
@@ -79,12 +79,12 @@ get_tlinux_name()
 		exit 1
 	fi
 
-	if [[ $raw_tagged_name != public-x86-* ]]; then
-		echo "$raw_tagged_name not valid tag name for public-x86"
+	if [[ $raw_tagged_name != x86-* ]]; then
+		echo "$raw_tagged_name not valid tag name for x86"
 		exit 11
 	fi
 
-	tagged_name=${raw_tagged_name#public-x86-}
+	tagged_name=${raw_tagged_name#x86-}
 
 	echo "${tagged_name}" | grep 'kasan'
 	if [ $?  -eq 0 ]; then

--- a/package/default/repackage/generate-rpms.sh
+++ b/package/default/repackage/generate-rpms.sh
@@ -33,12 +33,12 @@ get_kernel_version()
 	local tagged_name
 	raw_tagged_name=$tag_name
 
-	if [[ $raw_tagged_name != public-x86-* ]]; then
-                echo "$raw_tagged_name not valid tag name for public-x86"
+	if [[ $raw_tagged_name != x86-* ]]; then
+                echo "$raw_tagged_name not valid tag name for x86"
                 exit 1
         fi  
 
-	tagged_name=${raw_tagged_name#public-x86-}
+	tagged_name=${raw_tagged_name#x86-}
 
 	kernel_version=`echo $tagged_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
@@ -59,12 +59,12 @@ get_tlinux_name()
 		exit 1
 	fi
 
-	if [[ $raw_tagged_name != public-x86-* ]]; then
-                echo "$raw_tagged_name not valid tag name for public-x86"
-                exit 1
-        fi  
+	if [[ $raw_tagged_name != x86-* ]]; then
+		echo "$raw_tagged_name not valid tag name for x86"
+		exit 1
+	fi  
 
-    tagged_name=${raw_tagged_name#public-x86-}
+	tagged_name=${raw_tagged_name#x86-}
 
 	#if [ "${tagged_name#*-*-*}" != ${tagged_name} ];then
 		#echo "Error: bad tag name:$tagged_name."


### PR DESCRIPTION
generate-rpms: modify the name of the kernel tag for x86 and arm64

Signed-off-by: Honglin Li <honglinli@tencent.com>