### PR TITLE
copy part code from commid id 85d33df357b634649ddbe0a20fd2d0fc5732c3c…

### DIFF
--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -677,25 +677,21 @@ static int map_create(union bpf_attr *attr)
 	if (attr->btf_key_type_id || attr->btf_value_type_id) {
 		struct btf *btf;
 
-		if (!attr->btf_value_type_id) {
-			err = -EINVAL;
-			goto free_map;
-		}
-
 		btf = btf_get_by_fd(attr->btf_fd);
 		if (IS_ERR(btf)) {
 			err = PTR_ERR(btf);
 			goto free_map;
 		}
-
-		err = map_check_btf(map, btf, attr->btf_key_type_id,
-				    attr->btf_value_type_id);
-		if (err) {
-			btf_put(btf);
-			goto free_map;
-		}
-
 		map->btf = btf;
+
+		if (attr->btf_value_type_id) {
+			err = map_check_btf(map, btf, attr->btf_key_type_id,
+					attr->btf_value_type_id);
+			if (err) {
+				btf_put(btf);
+				goto free_map;
+			}
+		}
 		map->btf_key_type_id = attr->btf_key_type_id;
 		map->btf_value_type_id = attr->btf_value_type_id;
 	} else {


### PR DESCRIPTION
…b to linux 5.4 to fix sockhash map creation fail problem.

  logic:

  	sockhash map is defined in old way. like

	struct bpf_map_def __section("maps") sock_ops_map = {
        .type           = BPF_MAP_TYPE_SOCKHASH,
        .key_size       = sizeof(struct sock_key),
        .value_size     = sizeof(int),
        .max_entries    = 65535,
        .map_flags      = 0,
	};

	in this definition, value_size is provided without BTF type info.
	so that kernel map_create() shall not check its btf.

  Test case:
  	The opensource code create sockhash map
  	https://github.com/cyralinc/os-eBPF.git

	with this patch, load.sh will return ok.
	without this patch, load.sh will report create map fail.