### PR TITLE
add the package-requirement of grubby （raised by joey and rogerhui)

### DIFF
--- a/package/default/kernel-tlinux.spec
+++ b/package/default/kernel-tlinux.spec
@@ -52,6 +52,9 @@ BuildRequires: numactl-devel
 %endif
 %endif
 Requires(pre): linux-firmware >= 20150904-44
+Requires(pre): grubby
+Requires(post): %{_sbindir}/new-kernel-pkg
+Requires(preun): %{_sbindir}/new-kernel-pkg
 
 # for the 'hostname' command
 %if 0%{?rhel} >= 7


### PR DESCRIPTION
The TencentOS-installing with GUI need the grubby package, otherwise anaconda would throw "no such file: new-kernel-pkg".