### PR TITLE
kabi: fix kabi reserve place bug

### DIFF
--- a/include/linux/bio.h
+++ b/include/linux/bio.h
@@ -320,10 +320,11 @@ struct bio_integrity_payload {
 	struct work_struct	bip_work;	/* I/O completion */
 
 	struct bio_vec		*bip_vec;
-	struct bio_vec		bip_inline_vecs[0];/* embedded bvec array */
 
 	KABI_RESERVE(1);
 	KABI_RESERVE(2);
+
+	struct bio_vec		bip_inline_vecs[0];/* embedded bvec array */
 };
 
 #if defined(CONFIG_BLK_DEV_INTEGRITY)
@@ -722,12 +723,13 @@ struct bio_set {
 	spinlock_t		rescue_lock;
 	struct bio_list		rescue_list;
 	struct work_struct	rescue_work;
-	struct workqueue_struct	*rescue_workqueue;
 
 	KABI_RESERVE(1);
 	KABI_RESERVE(2);
 	KABI_RESERVE(3);
 	KABI_RESERVE(4);
+
+	struct workqueue_struct	*rescue_workqueue;
 };
 
 struct biovec_slab {

--- a/include/linux/genhd.h
+++ b/include/linux/genhd.h
@@ -132,12 +132,13 @@ struct hd_struct {
 	struct disk_stats dkstats;
 #endif
 	struct percpu_ref ref;
-	struct rcu_work rcu_work;
 
 	KABI_RESERVE(1);
 	KABI_RESERVE(2);
 	KABI_RESERVE(3);
 	KABI_RESERVE(4);
+
+	struct rcu_work rcu_work;
 };
 
 #define GENHD_FL_REMOVABLE			1

--- a/include/linux/mm_types.h
+++ b/include/linux/mm_types.h
@@ -353,12 +353,13 @@ struct vm_area_struct {
 #ifdef CONFIG_NUMA
 	struct mempolicy *vm_policy;	/* NUMA policy for the VMA */
 #endif
-	struct vm_userfaultfd_ctx vm_userfaultfd_ctx;
 
 	KABI_RESERVE(1);
 	KABI_RESERVE(2);
 	KABI_RESERVE(3);
 	KABI_RESERVE(4);
+
+	struct vm_userfaultfd_ctx vm_userfaultfd_ctx;
 } __randomize_layout;
 
 struct core_thread {

--- a/include/linux/module.h
+++ b/include/linux/module.h
@@ -448,6 +448,11 @@ struct module {
 	   keeping pointers to this stuff */
 	char *args;
 
+	KABI_RESERVE(1);
+	KABI_RESERVE(2);
+	KABI_RESERVE(3);
+	KABI_RESERVE(4);
+
 #ifdef CONFIG_SMP
 	/* Per-cpu data. */
 	void __percpu *percpu;
@@ -520,11 +525,6 @@ struct module {
 	struct error_injection_entry *ei_funcs;
 	unsigned int num_ei_funcs;
 #endif
-
-	KABI_RESERVE(1);
-	KABI_RESERVE(2);
-	KABI_RESERVE(3);
-	KABI_RESERVE(4);
 } ____cacheline_aligned __randomize_layout;
 #ifndef MODULE_ARCH_INIT
 #define MODULE_ARCH_INIT {}


### PR DESCRIPTION
    change place of some reserve words because they are placed under dynamic array

Signed-off-by: Denise Cheng <denisecheng@tencent.com>