### PR TITLE
ovl: check return value before using lookup_one_len_unlocked

### DIFF
--- a/fs/overlayfs/namei.c
+++ b/fs/overlayfs/namei.c
@@ -196,9 +196,8 @@ static struct dentry *ovl_lookup_positive_unlocked(const char *name,
 						   bool drop_negative)
 {
 	struct dentry *ret = lookup_one_len_unlocked(name, base, len);
-	unsigned int flags = smp_load_acquire(&ret->d_flags);
 
-	if (!IS_ERR(ret) && ((flags & DCACHE_ENTRY_TYPE) == DCACHE_MISS_TYPE)) {
+	if (!IS_ERR(ret) && d_flags_negative(smp_load_acquire(&ret->d_flags))) {
 		if (drop_negative && ret->d_lockref.count == 1) {
 			spin_lock(&ret->d_lock);
 			/* Recheck condition under lock */

--- a/include/linux/dcache.h
+++ b/include/linux/dcache.h
@@ -451,6 +451,11 @@ static inline bool d_is_negative(const struct dentry *dentry)
 	return d_is_miss(dentry);
 }
 
+static inline bool d_flags_negative(unsigned flags)
+{
+	return (flags & DCACHE_ENTRY_TYPE) == DCACHE_MISS_TYPE;
+}
+
 static inline bool d_is_positive(const struct dentry *dentry)
 {
 	return !d_is_negative(dentry);


### PR DESCRIPTION
[commit]: 1434a65ea625c51317ccdf06dabf4bd27d20fa10

After calling lookup_one_len_unlocked inside ovl_lookup_positive_unlocked,
the return dentry pointer is used before checking validity, which may represent
error code.

Signed-off-by: caelli <caelli@tencent.com>
Reviewed-by: benbjiang <benbjiang@tencent.com>
Reviewed-by: mengensun <mengensun@tencent.com>