### PR TITLE
fuse: add a dev ioctl for recovery

### DIFF
--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -870,6 +870,7 @@ struct fuse_notify_retrieve_in {
 
 /* Device ioctls: */
 #define FUSE_DEV_IOC_CLONE	_IOR(229, 0, uint32_t)
+#define FUSE_DEV_IOC_RECOVERY   _IOR(230, 0, uint32_t)
 
 struct fuse_lseek_in {
 	uint64_t	fh;


### PR DESCRIPTION
 For a simple read-only file system, as long as the connection
 is not broken, the recovery of the user-mode read-only file
 system process can be realized by putting the request of the
 processing list back into the pending list.

Signed-off-by: Peng Hao <flyingpeng@tencent.com>
Reviewed-by: benbjiang <benbjiang@tencent.com>
Reviewed-by: kaixuxia <kaixuxia@tencent.com>