### PR TITLE
getsockopt: add SO_MARK2 to get the MARK of flow

### DIFF
--- a/include/net/request_sock.h
+++ b/include/net/request_sock.h
@@ -63,6 +63,7 @@ struct request_sock {
 	u32				*saved_syn;
 	u32				secid;
 	u32				peer_secid;
+	u32				mark;
 };
 
 static inline struct request_sock *inet_reqsk(const struct sock *sk)

--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -423,6 +423,7 @@ struct sock {
 	struct timer_list	sk_timer;
 	__u32			sk_priority;
 	__u32			sk_mark;
+	__u32			sk_mark2;
 	unsigned long		sk_pacing_rate; /* bytes per second */
 	unsigned long		sk_max_pacing_rate;
 	struct page_frag	sk_frag;

--- a/include/uapi/asm-generic/socket.h
+++ b/include/uapi/asm-generic/socket.h
@@ -143,5 +143,7 @@
 #define SCM_TIMESTAMPING        SO_TIMESTAMPING
 
 #endif
+/* get the MARK of a flow which have been set by iptables*/
+#define SO_MARK2		1000
 
 #endif /* __ASM_GENERIC_SOCKET_H */

--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -1414,6 +1414,10 @@ int sock_getsockopt(struct socket *sock, int level, int optname,
 		v.val = sk->sk_mark;
 		break;
 
+	case SO_MARK2:
+		v.val = sk->sk_mark2;
+		break;
+
 	case SO_RXQ_OVFL:
 		v.val = sock_flag(sk, SOCK_RXQ_OVFL);
 		break;

--- a/net/ipv4/inet_connection_sock.c
+++ b/net/ipv4/inet_connection_sock.c
@@ -825,6 +825,7 @@ struct sock *inet_csk_clone_lock(const struct sock *sk,
 		struct inet_connection_sock *newicsk = inet_csk(newsk);
 
 		inet_sk_set_state(newsk, TCP_SYN_RECV);
+		newsk->sk_mark2 = req->mark;
 		newicsk->icsk_bind_hash = NULL;
 
 		inet_sk(newsk)->inet_dport = inet_rsk(req)->ir_rmt_port;

--- a/net/ipv4/tcp_input.c
+++ b/net/ipv4/tcp_input.c
@@ -6493,6 +6493,7 @@ static void tcp_openreq_init(struct request_sock *req,
 
 	req->rsk_rcv_wnd = 0;		/* So that tcp_send_synack() knows! */
 	req->cookie_ts = 0;
+	req->mark = skb->mark;
 	tcp_rsk(req)->rcv_isn = TCP_SKB_CB(skb)->seq;
 	tcp_rsk(req)->rcv_nxt = TCP_SKB_CB(skb)->seq + 1;
 	tcp_rsk(req)->snt_synack = 0;


### PR DESCRIPTION
add SO_MARK2 to get the MARK of flow
backport from tkernel2:
commit c6f2e27f7ad0b97ae0c162f70b6e0375f2270f27

Signed-off-by: Hongbo Li <herberthbli@tencent.com>
Signed-off-by: brookxu <brookxu@tencent.com>