### PR TITLE
 cpu/amd: default to enable erms/fsrm features for AMD EPYC 7K83

### DIFF
--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -934,6 +934,13 @@ static void init_amd(struct cpuinfo_x86 *c)
 	case 0x17: init_amd_zn(c); break;
 	}
 
+	/* force to enable erms/fsrm for AMD EPYC 7K8 cpu*/
+	if (c->x86 == 25) {
+		if (!strncmp(&c->x86_model_id[0],"AMD EPYC 7K83 64-Core Processor",31)) {
+			set_cpu_cap(c, X86_FEATURE_ERMS);
+			set_cpu_cap(c, X86_FEATURE_FSRM);
+		}
+	}
 	/*
 	 * Enable workaround for FXSAVE leak on CPUs
 	 * without a XSaveErPtr feature


### PR DESCRIPTION
For AMD EPYC 7K83 64-Core Processor, enable erms/fsrm features to
improve memory copy performance. This is just for specific cpu and
when the features are not transmitted to guest by the host.

Signed-off-by: Peng Hao <flyingpeng@tencent.com>