### PR TITLE
bpf: fix double free for btf in map_create()

### DIFF
--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -687,10 +687,8 @@ static int map_create(union bpf_attr *attr)
 		if (attr->btf_value_type_id) {
 			err = map_check_btf(map, btf, attr->btf_key_type_id,
 					attr->btf_value_type_id);
-			if (err) {
-				btf_put(btf);
+			if (err)
 				goto free_map;
-			}
 		}
 		map->btf_key_type_id = attr->btf_key_type_id;
 		map->btf_value_type_id = attr->btf_value_type_id;


### PR DESCRIPTION
'btf' is freed by btf_put() in map_create() if map_check_btf() fails.
However, it is freed again in free_map, which cause use-after-free
in the later process.

Fix this by remove redundant btf_put().

Fixes: c421e6e7b377 ("copy part code from commid id 85d33df357b634649ddbe0a20fd2d0fc5732c3cb to linux 5.4 to fix sockhash map creation fail problem")

Signed-off-by: Menglong Dong <imagedong@tencent.com>