### PR TITLE
memcg: solve the compilation problem with CONFIG_MEMCG=n

### DIFF
--- a/include/linux/sli.h
+++ b/include/linux/sli.h
@@ -48,10 +48,17 @@ struct sli_schedlat_stat {
 
 int  sli_cgroup_alloc(struct cgroup *cgroup);
 void sli_cgroup_free(struct cgroup *cgroup);
+#ifdef CONFIG_MEMCG
 void sli_memlat_stat_start(u64 *start);
 void sli_memlat_stat_end(enum sli_memlat_stat_item sidx, u64 start);
 int  sli_memlat_stat_show(struct seq_file *m, struct cgroup *cgrp);
 int  sli_memlat_max_show(struct seq_file *m, struct cgroup *cgrp);
+#else /* CONFIG_MEMCG */
+static inline void sli_memlat_stat_start(u64 *start){};
+static inline void sli_memlat_stat_end(enum sli_memlat_stat_item sidx, u64 start) {};
+static inline int sli_memlat_stat_show(struct seq_file *m, struct cgroup *cgrp) { return 0;};
+static inline int sli_memlat_max_show(struct seq_file *m, struct cgroup *cgrp) { return 0;};
+#endif
 void sli_schedlat_stat(struct task_struct *task,enum sli_schedlat_stat_item sidx, u64 delta);
 void sli_schedlat_rundelay(struct task_struct *task, struct task_struct *prev, u64 delta);
 int  sli_schedlat_stat_show(struct seq_file *m, struct cgroup *cgrp);
@@ -61,4 +68,5 @@ void sli_check_longsys(struct task_struct *tsk);
 #else
 static void sli_check_longsys(struct task_struct *tsk){};
 #endif
+
 #endif /*_LINUX_SLI_H*/

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -3437,7 +3437,6 @@ static int mem_cgroup_hierarchy_write(struct cgroup_subsys_state *css,
 
 #define MIN_PAGECACHE_PAGES 16
 
-unsigned int vm_pagecache_limit_retry_times;
 void mem_cgroup_shrink_pagecache(struct mem_cgroup *memcg, gfp_t gfp_mask)
 {
 	unsigned long pages_used, pages_max, pages_reclaimed, goal_pages_used, pre_used;
@@ -3577,7 +3576,7 @@ unsigned long mem_cgroup_pagecache_get_reclaim_pages(struct mem_cgroup *memcg)
 
 static void pagecache_set_limit(struct mem_cgroup *memcg)
 {
-	unsigned long max, pre, pages_max;
+	unsigned long max, pages_max;
 	u32 max_ratio;
 
 	pages_max = READ_ONCE(memcg->memory.max);

--- a/mm/swap.c
+++ b/mm/swap.c
@@ -735,7 +735,6 @@ void release_pages(struct page **pages, int nr)
 {
 	int i;
 	LIST_HEAD(pages_to_free);
-	struct pglist_data *locked_pgdat = NULL;
 	struct lruvec *lruvec = NULL;
 	unsigned long uninitialized_var(flags);
 	unsigned int uninitialized_var(lock_batch);

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -167,6 +167,7 @@ struct scan_control {
  */
 int vm_swappiness = 60;
 unsigned long vm_pagecache_limit_pages __read_mostly = 0;
+unsigned int vm_pagecache_limit_retry_times __read_mostly = 0;
 unsigned long vm_pagecache_limit_reclaim_pages = 0;
 int vm_pagecache_limit_ratio __read_mostly = 0;
 int vm_pagecache_limit_reclaim_ratio __read_mostly = 0;
@@ -4281,6 +4282,7 @@ out:
 	return nr_locked_zones;
 }
 
+#ifdef CONFIG_MEMCG
 /*
  * Function to shrink the page cache
  *
@@ -4390,6 +4392,12 @@ out:
 
 	return sc.nr_reclaimed;
 }
+#else /* CONFIG_MEMCG */
+static unsigned long __shrink_page_cache(gfp_t mask, struct mem_cgroup *memcg, unsigned long nr_pages)
+{
+	return 0;
+}
+#endif
 
 static int kpagecache_limitd(void *data)
 {


### PR DESCRIPTION
When CONFIG_MEMCG is not configured, per-cgroup lru-lock, sli, and
cgroup-based page cache restrictions will cause compilation problems.

Signed-off-by: Peng Hao <flyingpeng@tencent.com>