### PR TITLE
qspinlock: Diable virt_spin_lock for dedicated vm

### DIFF
--- a/arch/x86/kernel/kvm.c
+++ b/arch/x86/kernel/kvm.c
@@ -838,7 +838,7 @@ void __init kvm_spinlock_init(void)
 	 */
 	if (!kvm_para_has_feature(KVM_FEATURE_PV_UNHALT)) {
 		pr_info("PV spinlocks disabled, no host support\n");
-		return;
+		goto out;
 	}
 
 	/*


### PR DESCRIPTION
For the  mwait-passthrough vm, KVM_FEATURE_PV_UNHALT will not be set.
The current kernel  will use  native_queued_spin_lock_slowpath
instead of __pv_queued_spin_lock_slowpath without disabling virt_spin_lock_key,
that is, native_queued_spin_lock_slowpath always use CAS (compare and swap),
which will result in performance regression.

Signed-off-by: mungerjiang<mungerjiang@tencent.com>