### PR TITLE
fs:ovl: omit sync_filesystem to when sync overlayfs

### DIFF
--- a/fs/overlayfs/super.c
+++ b/fs/overlayfs/super.c
@@ -252,7 +252,6 @@ static void ovl_put_super(struct super_block *sb)
 	ovl_free_fs(ofs);
 }
 
-/* Sync real dirty inodes in upper filesystem (if it exists) */
 static int ovl_sync_fs(struct super_block *sb, int wait)
 {
 	struct ovl_fs *ofs = sb->s_fs_info;
@@ -262,21 +261,12 @@ static int ovl_sync_fs(struct super_block *sb, int wait)
 	if (!ofs->upper_mnt)
 		return 0;
 
-	/*
-	 * If this is a sync(2) call or an emergency sync, all the super blocks
-	 * will be iterated, including upper_sb, so no need to do anything.
-	 *
-	 * If this is a syncfs(2) call, then we do need to call
-	 * sync_filesystem() on upper_sb, but enough if we do it when being
-	 * called with wait == 1.
-	 */
-	if (!wait)
+	upper_sb = ofs->upper_mnt->mnt_sb;
+	if (!upper_sb->s_op->sync_fs)
 		return 0;
 
-	upper_sb = ofs->upper_mnt->mnt_sb;
-
 	down_read(&upper_sb->s_umount);
-	ret = sync_filesystem(upper_sb);
+	ret = upper_sb->s_op->sync_fs(upper_sb, wait);
 	up_read(&upper_sb->s_umount);
 
 	return ret;


### PR DESCRIPTION
When umounting overlayfs, it's unnecessary to call sync_filesystem,
because upper fs will make everything work fine.

Signed-off-by: lennychen <lennychen@tencent.com>