### PR TITLE
cgroupfs: add files inside sys

### DIFF
--- a/fs/cgroupfs/cgroupfs.h
+++ b/fs/cgroupfs/cgroupfs.h
@@ -1,17 +1,15 @@
 #ifndef __LINUX_CGROUPFS_H
 #define __LINUX_CGROUPFS_H
-enum cgroupfs_file_type{
-	CGROUPFS_TYPE_MEMINFO,
-	CGROUPFS_TYPE_CPUINFO,
-	CGROUPFS_TYPE_STAT,
-	CGROUPFS_TYPE_UPTIME,
-	CGROUPFS_TYPE_LOADAVG,
-	CGROUPFS_TYPE_DKSTATS,
-	CGROUPFS_TYPE_VMSTAT,
-	CGROUPFS_TYPE_CPUDIR,
-	CGROUPFS_TYPE_NORMAL_DIR,
-	CGROUPFS_TYPE_LAST,
-};
+#define CGROUPFS_TYPE_MEMINFO		(1 << 0)
+#define CGROUPFS_TYPE_CPUINFO		(1 << 1)
+#define CGROUPFS_TYPE_STAT		(1 << 2)
+#define CGROUPFS_TYPE_UPTIME		(1 << 3)
+#define CGROUPFS_TYPE_LOADAVG		(1 << 4)
+#define CGROUPFS_TYPE_DKSTATS		(1 << 5)
+#define CGROUPFS_TYPE_VMSTAT		(1 << 6)
+#define CGROUPFS_TYPE_CPUDIR		(1 << 7)
+#define CGROUPFS_TYPE_NORMAL_DIR	(1 << 8)
+#define CGROUPFS_TYPE_AUTO_MOUNT	(1 << 9)
 
 typedef struct cgroupfs_entry {
 	struct rb_root subdir;
@@ -28,6 +26,7 @@ typedef struct cgroupfs_entry {
 	const struct inode_operations *e_iops;
 	const struct file_operations *e_fops;
 	const struct dentry_operations *e_dops;
+	void *private;
 	KABI_RESERVE(1);
 	KABI_RESERVE(2);
 	KABI_RESERVE(3);

--- a/fs/cgroupfs/sys.c
+++ b/fs/cgroupfs/sys.c
@@ -1,13 +1,22 @@
 #include <linux/fs.h>
 #include <linux/fs_context.h>
+#include <linux/init_task.h>
+#include <linux/fs_struct.h>
+#include "../internal.h"
 #include "cgroupfs.h"
 
 extern int cpu_get_max_cpus(struct task_struct *p);
 extern int cpuset_cgroups_cpu_allowed(struct task_struct *task, int cpu, int once);
 
-static int cgroupfs_dop_revalidate(struct dentry *dentry, unsigned int flags)
+static int __attribute__((unused)) cgroupfs_dop_revalidate(
+			struct dentry *dentry, unsigned int flags)
 {
-	return 0;
+	cgroupfs_entry_t *en;
+
+	en = dentry->d_inode->i_private;
+	if (en->cgroupfs_type & CGROUPFS_TYPE_CPUDIR)
+		return 0;
+	return 1;
 }
 
 int cgroupfs_cpu_dir_filter(int cpu, int *max_cpu, int *counted_cpu, int once)
@@ -24,9 +33,26 @@ int cgroupfs_cpu_dir_filter(int cpu, int *max_cpu, int *counted_cpu, int once)
 	return 0;
 }
 
+static struct vfsmount *cgroupfs_dop_auto_mount(struct path *target)
+{
+	cgroupfs_entry_t *en;
+	struct path path;
+	int err;
+
+	en = target->dentry->d_inode->i_private;
+	err = vfs_path_lookup(init_task.fs->root.dentry, init_task.fs->root.mnt,
+		en->private, 0, &path);
+	if (err)
+		return ERR_PTR(err);
+	dput(target->dentry);
+	target->dentry = path.dentry;
+	target->mnt = path.mnt;
+	return 0;
+}
+
 const struct dentry_operations cgroupfs_dir_dops = {
-	.d_revalidate   = cgroupfs_dop_revalidate,
 	.d_delete       = always_delete_dentry,
+	.d_automount    = cgroupfs_dop_auto_mount,
 };
 
 void cgroupfs_set_sys_dops(cgroupfs_entry_t *en)


### PR DESCRIPTION
Add files inside /cgroupfs/sys/devices/system/cpu/, currently sysfs
mounted on /sys/ before cgroupfs is required, we use d_automount
interface to switch from cgroupfs to sysfs.

Signed-off-by: caelli <caelli@tencent.com>
Reviewed-by: Bin Lai <robinlai@tencent.com>