### PR TITLE
Pagecache limit linuszeng

### DIFF
--- a/include/linux/memcontrol.h
+++ b/include/linux/memcontrol.h
@@ -1474,7 +1474,7 @@ bool mem_cgroup_charge_skmem(struct mem_cgroup *memcg, unsigned int nr_pages);
 void mem_cgroup_uncharge_skmem(struct mem_cgroup *memcg, unsigned int nr_pages);
 #ifdef CONFIG_MEMCG
 
-extern unsigned int vm_pagecache_limit_retry_times __read_mostly;
+extern unsigned int vm_pagecache_limit_retry_times;
 extern void mem_cgroup_shrink_pagecache(struct mem_cgroup *memcg, gfp_t gfp_mask);
 
 extern struct static_key_false memcg_sockets_enabled_key;

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -3437,7 +3437,7 @@ static int mem_cgroup_hierarchy_write(struct cgroup_subsys_state *css,
 
 #define MIN_PAGECACHE_PAGES 16
 
-unsigned int vm_pagecache_limit_retry_times;
+unsigned int vm_pagecache_limit_retry_times __read_mostly = MEM_CGROUP_RECLAIM_RETRIES;
 void mem_cgroup_shrink_pagecache(struct mem_cgroup *memcg, gfp_t gfp_mask)
 {
 	unsigned long pages_used, pages_max, pages_reclaimed, goal_pages_used, pre_used;

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -175,7 +175,7 @@ unsigned int vm_pagecache_limit_async __read_mostly = 0;
 unsigned int vm_pagecache_ignore_slab __read_mostly = 1;
 static struct task_struct *kpclimitd = NULL;
 static bool kpclimitd_context = false;
-unsigned int vm_pagecache_limit_global __read_mostly = 1;
+unsigned int vm_pagecache_limit_global __read_mostly = 0;
 /*
  * The total number of pages which are beyond the high watermark within all
  * zones.


### PR DESCRIPTION
开启per-memcg pagecache limit特性：
1.在cgroup v1的版本上，通过memory.limit_in_bytes设置cgroup的内存用量；在cgroup v2版本上，通过memory.max设置cgroup的内存用量。
2.通过memory.pagecache.max_ratio设置pagecache占cgroup内存用量的比例。

立即回收pagecache：
通过echo [5, 100] > memory.pagecache.reclaim_ratio设置pagecache回收比例，并且立即进行一次回收，默认值为5。

查看pagecache用量：
cat memory.pagecache.current

相关sysctl的默认值：
vm.pagecache_limit_retry_times = 5
m.pagecache_limit_global = 0