### PR TITLE
 mm/vmscan: fix shmctl SHM_UNLOCK triggering an warning

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -4774,8 +4774,8 @@ void check_move_unevictable_pages(struct pagevec *pvec)
 			del_page_from_lru_list(page, lruvec, LRU_UNEVICTABLE);
 			add_page_to_lru_list(page, lruvec, lru);
 			pgrescued++;
-			SetPageLRU(page);
 		}
+		SetPageLRU(page);
 	}
 
 	if (lruvec) {


### PR DESCRIPTION
The problem arose after the introduction of the TestClearPageLRU.
After executing SHM_UNLOCK, the mapping for the shared memory area
becomes evictable, and the subsequent pages generated within
the shared area are evictable. In this case, also set the page
to PageLRU.

Signed-off-by: Peng Hao <flyingpeng@tencent.com>