### PR TITLE
修复磁盘挂死显示0% io util问题

### DIFF
--- a/block/blk-cgroup.c
+++ b/block/blk-cgroup.c
@@ -721,7 +721,9 @@ static void blkcg_dkstats_seqf_print(struct blkcg *blkcg, struct hd_struct *hd,
 	char buf[BDEVNAME_SIZE];
 	unsigned long rd_nsecs = blkcg_part_stat_read(blkcg, hd, nsecs[READ]);
 	unsigned long wr_nsecs = blkcg_part_stat_read(blkcg, hd, nsecs[WRITE]);
+	struct request_queue *q = part_to_disk(hd)->queue;
 
+	sync_io_ticks(hd, blk_queue_quiesced(q) || part_in_flight(q, hd) > 0);
 	seq_printf(seqf, "%4d %7d %s %lu %lu %lu "
 		   "%u %lu %lu %lu %u %u %u %u %u %u\n",
 		   MAJOR(part_devt(hd)), MINOR(part_devt(hd)),

--- a/block/blk-mq.c
+++ b/block/blk-mq.c
@@ -105,7 +105,7 @@ static bool blk_mq_check_inflight(struct blk_mq_hw_ctx *hctx,
 	/*
 	 * index[0] counts the specific partition that was asked for.
 	 */
-	if (rq->part == mi->part)
+	if (!mi->part->partno || rq->part == mi->part)
 		mi->inflight[0]++;
 
 	return true;

--- a/block/genhd.c
+++ b/block/genhd.c
@@ -1382,6 +1382,7 @@ static int diskstats_show(struct seq_file *seqf, void *v)
 	disk_part_iter_init(&piter, gp, DISK_PITER_INCL_EMPTY_PART0);
 	while ((hd = disk_part_iter_next(&piter))) {
 		inflight = part_in_flight(gp->queue, hd);
+		sync_io_ticks(hd, inflight > 0 || blk_queue_quiesced(gp->queue));
 		seq_printf(seqf, "%4d %7d %s "
 			   "%lu %lu %lu %u "
 			   "%lu %lu %lu %u "

--- a/block/partition-generic.c
+++ b/block/partition-generic.c
@@ -123,6 +123,7 @@ ssize_t part_stat_show(struct device *dev,
 	unsigned int inflight;
 
 	inflight = part_in_flight(q, p);
+	sync_io_ticks(p, inflight > 0 || blk_queue_quiesced(q));
 	return sprintf(buf,
 		"%8lu %8lu %8llu %8u "
 		"%8lu %8lu %8llu %8u "

--- a/include/linux/genhd.h
+++ b/include/linux/genhd.h
@@ -348,6 +348,7 @@ static inline int init_part_stats(struct hd_struct *part)
 	part->dkstats = alloc_percpu(struct disk_stats);
 	if (!part->dkstats)
 		return 0;
+	part->stamp = jiffies - 1;
 	return 1;
 }
 
@@ -436,6 +437,7 @@ static inline void free_part_info(struct hd_struct *part)
 }
 
 void update_io_ticks(struct hd_struct *part, unsigned long now, bool end);
+void sync_io_ticks(struct hd_struct *part, bool busy);
 
 /* block/genhd.c */
 extern void device_add_disk(struct device *parent, struct gendisk *disk,


### PR DESCRIPTION
在请求挂死或者queue quiesce时，io_ticks没更新，从proc读到的值不增加，导致ioutil显示为0。这个patch在读取proc时，会更新上次统计到当前时间的io_ticks值，从而达到显示100% util。