### PR TITLE
fix compile error when open CONFIG ACPI APEI on arm64

### DIFF
--- a/drivers/acpi/apei/hest.c
+++ b/drivers/acpi/apei/hest.c
@@ -141,11 +141,13 @@ static int __init hest_parse_ghes_count(struct acpi_hest_header *hest_hdr, void 
 {
 	int *count = data;
 
-	if ((hest_hdr->type == ACPI_HEST_TYPE_GENERIC_ERROR ||
-	     hest_hdr->type == ACPI_HEST_TYPE_GENERIC_ERROR_V2) &&
-	    (boot_cpu_data.x86_vendor != X86_VENDOR_AMD ||
-	     !(hest_hdr->source_id &0xF000)))
-		(*count)++;
+	if (hest_hdr->type == ACPI_HEST_TYPE_GENERIC_ERROR ||
+	    hest_hdr->type == ACPI_HEST_TYPE_GENERIC_ERROR_V2) {
+#ifdef	CONFIG_X86
+		if (boot_cpu_data.x86_vendor != X86_VENDOR_AMD || !(hest_hdr->source_id & 0xF000))
+#endif
+			(*count)++;
+	}
 	return 0;
 }
 
@@ -155,11 +157,14 @@ static int __init hest_parse_ghes(struct acpi_hest_header *hest_hdr, void *data)
 	struct ghes_arr *ghes_arr = data;
 	int rc, i;
 
-	if ((hest_hdr->type != ACPI_HEST_TYPE_GENERIC_ERROR &&
-	     hest_hdr->type != ACPI_HEST_TYPE_GENERIC_ERROR_V2) ||
-	    ((hest_hdr->source_id & 0xF000) &&
-	     boot_cpu_data.x86_vendor == X86_VENDOR_AMD))
+	if (hest_hdr->type != ACPI_HEST_TYPE_GENERIC_ERROR &&
+	    hest_hdr->type != ACPI_HEST_TYPE_GENERIC_ERROR_V2)
 		return 0;
+
+#ifdef	CONFIG_X86
+	if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD && (hest_hdr->source_id & 0xF000))
+		return 0;
+#endif
 
 	if (!((struct acpi_hest_generic *)hest_hdr)->enabled)
 		return 0;


### PR DESCRIPTION
fix the compile error as below (when open CONFIG ACPI APEI on arm64):
drivers/acpi/apei/hest.c: In function ‘hest_parse_ghes_count’:
drivers/acpi/apei/hest.c:146:7: error: ‘boot_cpu_data’ undeclared (first use in this function); did you mean ‘bootmem_data’?
      (boot_cpu_data.x86_vendor != X86_VENDOR_AMD ||
       ^~~~~~~~~~~~~
       bootmem_data
drivers/acpi/apei/hest.c:146:7: note: each undeclared identifier is reported only once for each function it appears in
drivers/acpi/apei/hest.c:146:35: error: ‘X86_VENDOR_AMD’ undeclared (first use in this function); did you mean ‘X86_VENDOR_ANY’?
      (boot_cpu_data.x86_vendor != X86_VENDOR_AMD ||
                                   ^~~~~~~~~~~~~~
                                   X86_VENDOR_ANY
drivers/acpi/apei/hest.c: In function ‘hest_parse_ghes’:
drivers/acpi/apei/hest.c:161:7: error: ‘boot_cpu_data’ undeclared (first use in this function); did you mean ‘bootmem_data’?
       boot_cpu_data.x86_vendor == X86_VENDOR_AMD))
       ^~~~~~~~~~~~~
       bootmem_data
drivers/acpi/apei/hest.c:161:35: error: ‘X86_VENDOR_AMD’ undeclared (first use in this function); did you mean ‘X86_VENDOR_ANY’?
       boot_cpu_data.x86_vendor == X86_VENDOR_AMD))
                                   ^~~~~~~~~~~~~~
                                   X86_VENDOR_ANY
make[3]: *** [scripts/Makefile.build:261: drivers/acpi/apei/hest.o] Error 1
make[2]: *** [scripts/Makefile.build:496: drivers/acpi/apei] Error 2
make[1]: *** [scripts/Makefile.build:496: drivers/acpi] Error 2
make: *** [Makefile:1734: drivers] Error 2