### PR TITLE
Revert "mm/page_alloc: allow high-order pages on the per-cpu lists"

### DIFF
--- a/include/linux/gfp.h
+++ b/include/linux/gfp.h
@@ -565,7 +565,7 @@ void * __meminit alloc_pages_exact_nid(int nid, size_t size, gfp_t gfp_mask);
 
 extern void __free_pages(struct page *page, unsigned int order);
 extern void free_pages(unsigned long addr, unsigned int order);
-extern void free_unref_page(struct page *page, unsigned int order);
+extern void free_unref_page(struct page *page);
 extern void free_unref_page_list(struct list_head *list);
 
 struct page_frag_cache;

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -327,24 +327,6 @@ enum zone_watermarks {
 	NR_WMARK
 };
 
-/*
- * One per migratetype for each PAGE_ALLOC_COSTLY_ORDER plus one additional
- * for pageblock size for THP if configured.
- */
-#ifdef CONFIG_TRANSPARENT_HUGEPAGE
-#define NR_PCP_THP 1
-#else
-#define NR_PCP_THP 0
-#endif
-#define NR_PCP_LISTS (MIGRATE_PCPTYPES * (PAGE_ALLOC_COSTLY_ORDER + 1 + NR_PCP_THP))
-
-/*
- * Shift to encode migratetype and order in the same integer, with order
- * in the least significant bits.
- */
-#define NR_PCP_ORDER_WIDTH 8
-#define NR_PCP_ORDER_MASK ((1<<NR_PCP_ORDER_WIDTH) - 1)
-
 #define min_wmark_pages(z) (z->_watermark[WMARK_MIN] + z->watermark_boost)
 #define low_wmark_pages(z) (z->_watermark[WMARK_LOW] + z->watermark_boost)
 #define high_wmark_pages(z) (z->_watermark[WMARK_HIGH] + z->watermark_boost)
@@ -356,7 +338,7 @@ struct per_cpu_pages {
 	int batch;		/* chunk size for buddy add/remove */
 
 	/* Lists of pages, one per migrate type stored on the pcp-lists */
-	struct list_head lists[NR_PCP_LISTS];
+	struct list_head lists[MIGRATE_PCPTYPES];
 };
 
 struct per_cpu_pageset {

--- a/mm/swap.c
+++ b/mm/swap.c
@@ -76,7 +76,7 @@ static void __put_single_page(struct page *page)
 {
 	__page_cache_release(page);
 	mem_cgroup_uncharge(page);
-	free_unref_page(page, 0);
+	free_unref_page(page);
 }
 
 static void __put_compound_page(struct page *page)


### PR DESCRIPTION
Due to unstable results on some machines, revert the backport.
This reverts commit 5312a9ff49b10e9ae70ae7e756f7d28cb22afd22.