### PR TITLE
Support buffer I/O qos function in cgroup v1

### DIFF
--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -60,6 +60,8 @@ EXPORT_TRACEPOINT_SYMBOL_GPL(block_unplug);
 
 DEFINE_IDA(blk_queue_ida);
 
+unsigned int sysctl_io_qos_enabled = 0;
+
 /*
  * For queue allocation
  */

--- a/include/linux/backing-dev.h
+++ b/include/linux/backing-dev.h
@@ -255,9 +255,7 @@ static inline bool inode_cgwb_enabled(struct inode *inode)
 {
 	struct backing_dev_info *bdi = inode_to_bdi(inode);
 
-	return cgroup_subsys_on_dfl(memory_cgrp_subsys) &&
-		cgroup_subsys_on_dfl(io_cgrp_subsys) &&
-		bdi_cap_account_dirty(bdi) &&
+	return bdi_cap_account_dirty(bdi) &&
 		(bdi->capabilities & BDI_CAP_CGROUP_WRITEBACK) &&
 		(inode->i_sb->s_iflags & SB_I_CGROUPWB);
 }

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -1846,4 +1846,5 @@ static inline void blk_wake_io_task(struct task_struct *waiter)
 		wake_up_process(waiter);
 }
 
+extern unsigned int sysctl_io_qos_enabled;
 #endif

--- a/include/linux/memcontrol.h
+++ b/include/linux/memcontrol.h
@@ -340,6 +340,10 @@ struct mem_cgroup {
 	struct deferred_split deferred_split_queue;
 #endif
 
+	/* attach a blkio with memcg for cgroup v1 */
+	struct cgroup_subsys_state *bind_blkio;
+	char *bind_blkio_path;
+
 	struct mem_cgroup_per_node *nodeinfo[0];
 	/* WARNING: nodeinfo must be the last member here */
 };

--- a/kernel/cgroup/cgroup.c
+++ b/kernel/cgroup/cgroup.c
@@ -2697,6 +2697,7 @@ void cgroup_migrate_add_src(struct css_set *src_cset,
 int cgroup_migrate_prepare_dst(struct cgroup_mgctx *mgctx)
 {
 	struct css_set *src_cset, *tmp_cset;
+	struct cgroup_subsys_state *css;
 
 	lockdep_assert_held(&cgroup_mutex);
 
@@ -2712,6 +2713,18 @@ int cgroup_migrate_prepare_dst(struct cgroup_mgctx *mgctx)
 			return -ENOMEM;
 
 		WARN_ON_ONCE(src_cset->mg_dst_cset || dst_cset->mg_dst_cset);
+
+		css = dst_cset->subsys[memory_cgrp_id];
+		if (css) {
+			struct mem_cgroup *memcg = mem_cgroup_from_css(css);
+
+			css = dst_cset->subsys[io_cgrp_id];
+			if (css && memcg->bind_blkio && css != blkcg_root_css &&
+				memcg->bind_blkio != css) {
+				pr_err("memcg already bind blkio, disallow migrate");
+				return -EPERM;
+			}
+		}
 
 		/*
 		 * If src cset equals dst, it's noop.  Drop the src.

--- a/kernel/cgroup/cgroup.c
+++ b/kernel/cgroup/cgroup.c
@@ -2694,6 +2694,8 @@ void cgroup_migrate_add_src(struct css_set *src_cset,
  * using cgroup_migrate(), cgroup_migrate_finish() must be called on
  * @mgctx.
  */
+unsigned int sysctl_allow_memcg_migrate_ignore_blkio_bind;
+
 int cgroup_migrate_prepare_dst(struct cgroup_mgctx *mgctx)
 {
 	struct css_set *src_cset, *tmp_cset;
@@ -2715,7 +2717,7 @@ int cgroup_migrate_prepare_dst(struct cgroup_mgctx *mgctx)
 		WARN_ON_ONCE(src_cset->mg_dst_cset || dst_cset->mg_dst_cset);
 
 		css = dst_cset->subsys[memory_cgrp_id];
-		if (css) {
+		if (!sysctl_allow_memcg_migrate_ignore_blkio_bind && css) {
 			struct mem_cgroup *memcg = mem_cgroup_from_css(css);
 
 			css = dst_cset->subsys[io_cgrp_id];

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -69,6 +69,7 @@
 #include <linux/mount.h>
 #include <linux/userfaultfd_k.h>
 #include <linux/trackgpu.h>
+#include <linux/blkdev.h>
 
 #include "../lib/kstrtox.h"
 
@@ -1471,6 +1472,15 @@ static struct ctl_table kern_table[] = {
 		.data		= &sysctl_qos_mbuf_enable,
 		.maxlen		= sizeof(int),
 		.mode		= 0600,
+		.proc_handler	= proc_dointvec_minmax,
+		.extra1		= SYSCTL_ZERO,
+		.extra2		= SYSCTL_ONE,
+	},
+	{
+		.procname	= "io_qos",
+		.data		= &sysctl_io_qos_enabled,
+		.maxlen		= sizeof(unsigned int),
+		.mode		= 0644,
 		.proc_handler	= proc_dointvec_minmax,
 		.extra1		= SYSCTL_ZERO,
 		.extra2		= SYSCTL_ONE,

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -134,6 +134,8 @@ extern int max_softirq_accel_mask;
 static int sixty = 60;
 #endif
 
+extern unsigned int sysctl_allow_memcg_migrate_ignore_blkio_bind;
+
 static int __maybe_unused neg_one = -1;
 static int __maybe_unused two = 2;
 static int __maybe_unused four = 4;
@@ -1466,6 +1468,15 @@ static struct ctl_table kern_table[] = {
 		.proc_handler   = proc_dointvec_minmax,
 		.extra1         = SYSCTL_ZERO,
 		.extra2         = SYSCTL_ONE,
+	},
+	{
+		.procname	= "allow_memcg_migrate_ignore_blkio_bind",
+		.data		= &sysctl_allow_memcg_migrate_ignore_blkio_bind,
+		.maxlen		= sizeof(unsigned int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec_minmax,
+		.extra1		= SYSCTL_ZERO,
+		.extra2		= SYSCTL_ONE,
 	},
 	{
 		.procname	= "qos_mbuf_enable",

--- a/mm/backing-dev.c
+++ b/mm/backing-dev.c
@@ -538,8 +538,10 @@ static int cgwb_create(struct backing_dev_info *bdi,
 	memcg = mem_cgroup_from_css(memcg_css);
 	if (cgroup_subsys_on_dfl(memory_cgrp_subsys))
 		blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
-	else
+	else {
 		blkcg_css = memcg->bind_blkio ?: blkcg_root_css;
+		css_get(blkcg_css);
+	}
 	blkcg = css_to_blkcg(blkcg_css);
 	memcg_cgwb_list = &memcg->cgwb_list;
 	blkcg_cgwb_list = &blkcg->cgwb_list;
@@ -662,8 +664,10 @@ struct bdi_writeback *wb_get_lookup(struct backing_dev_info *bdi,
 		memcg = mem_cgroup_from_css(memcg_css);
 		if (cgroup_subsys_on_dfl(memory_cgrp_subsys))
 			blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
-		else
+		else {
 			blkcg_css = memcg->bind_blkio ?: blkcg_root_css;
+			css_get(blkcg_css);
+		}
 		if (unlikely(wb->blkcg_css != blkcg_css || !wb_tryget(wb)))
 			wb = NULL;
 		css_put(blkcg_css);

--- a/mm/backing-dev.c
+++ b/mm/backing-dev.c
@@ -536,7 +536,10 @@ static int cgwb_create(struct backing_dev_info *bdi,
 	int ret = 0;
 
 	memcg = mem_cgroup_from_css(memcg_css);
-	blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
+	if (cgroup_subsys_on_dfl(memory_cgrp_subsys))
+		blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
+	else
+		blkcg_css = memcg->bind_blkio ?: blkcg_root_css;
 	blkcg = css_to_blkcg(blkcg_css);
 	memcg_cgwb_list = &memcg->cgwb_list;
 	blkcg_cgwb_list = &blkcg->cgwb_list;
@@ -653,9 +656,14 @@ struct bdi_writeback *wb_get_lookup(struct backing_dev_info *bdi,
 	wb = radix_tree_lookup(&bdi->cgwb_tree, memcg_css->id);
 	if (wb) {
 		struct cgroup_subsys_state *blkcg_css;
+		struct mem_cgroup *memcg;
 
 		/* see whether the blkcg association has changed */
-		blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
+		memcg = mem_cgroup_from_css(memcg_css);
+		if (cgroup_subsys_on_dfl(memory_cgrp_subsys))
+			blkcg_css = cgroup_get_e_css(memcg_css->cgroup, &io_cgrp_subsys);
+		else
+			blkcg_css = memcg->bind_blkio ?: blkcg_root_css;
 		if (unlikely(wb->blkcg_css != blkcg_css || !wb_tryget(wb)))
 			wb = NULL;
 		css_put(blkcg_css);

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -5406,14 +5406,14 @@ static ssize_t mem_cgroup_bind_blkio_write(struct kernfs_open_file *of,
 		memcg->bind_blkio_path = NULL;
 		css_put(memcg->bind_blkio);
 		memcg->bind_blkio = NULL;
+
+		wb_memcg_offline(memcg);
+		INIT_LIST_HEAD(&memcg->cgwb_list);
 	}
 
 	if (!strnlen(buf, PATH_MAX)) {
 		mutex_unlock(&memcg_max_mutex);
 		kfree(pbuf);
-
-		wb_memcg_offline(memcg);
-		INIT_LIST_HEAD(&memcg->cgwb_list);
 		return nbytes;
 	}
 

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -5390,6 +5390,9 @@ static ssize_t mem_cgroup_bind_blkio_write(struct kernfs_open_file *of,
 	char *pbuf;
 	int ret;
 
+	if (!sysctl_io_qos_enabled)
+		return -EPERM;
+
 	buf = strstrip(buf);
 
 	/* alloc memory outside mutex */


### PR DESCRIPTION
Backport buffer io qos function in cgroup v1.

Add the ability to bind I/O path to memory cgroup to support seperate buffer I/O read/write's bpf/iops qos function.