### PR TITLE
net: bpf: fix used-after-free BUG in inet_twsk_kill

### DIFF
--- a/net/ipv4/inet_timewait_sock.c
+++ b/net/ipv4/inet_timewait_sock.c
@@ -49,6 +49,7 @@ static void inet_twsk_kill(struct inet_timewait_sock *tw)
 	struct inet_bind_hashbucket *bhead;
 
 	BPF_CGROUP_RUN_PROG_TW_CLOSE((struct sock *)tw);
+	cgroup_sk_free(&tw->tw_cgrp_data);
 
 	spin_lock(lock);
 	sk_nulls_del_node_init_rcu((struct sock *)tw);
@@ -188,6 +189,7 @@ struct inet_timewait_sock *inet_twsk_alloc(const struct sock *sk,
 		tw->tw_transparent  = inet->transparent;
 		tw->tw_prot	    = sk->sk_prot_creator;
 		tw->tw_cgrp_data    = sk->sk_cgrp_data;
+		cgroup_sk_clone(&tw->tw_cgrp_data);
 		atomic64_set(&tw->tw_cookie, atomic64_read(&sk->sk_cookie));
 		twsk_net_set(tw, sock_net(sk));
 		timer_setup(&tw->tw_timer, tw_timer_handler, TIMER_PINNED);


### PR DESCRIPTION
In the commit
e22ef12b563a ("net: bpf: add BPF_CGROUP_TWSK_CLOSE for tcp timewait sock close")
the new eBPF hook 'BPF_CGROUP_TWSK_CLOSE' is added. However, it doesn't
free 'tw->tw_cgrp_data' properly.

Fix this by call 'cgroup_sk_clone()' while tw sock create and call
'cgroup_sk_free' while it is freed.

Signed-off-by: Menglong Dong <imagedong@tencent.com>