### PR TITLE
net: bpf: fix uninitialized data_meta in xdp

### DIFF
--- a/drivers/net/ethernet/intel/i40e/i40e_txrx.c
+++ b/drivers/net/ethernet/intel/i40e/i40e_txrx.c
@@ -2612,6 +2612,7 @@ static int i40e_clean_rx_irq(struct i40e_ring *rx_ring, int budget)
 		if (!skb) {
 			xdp.data = page_address(rx_buffer->page) +
 				   rx_buffer->page_offset;
+			xdp_set_data_meta_invalid(&xdp);
 			xdp.data_hard_start = (void *)((u8 *)xdp.data -
 					      i40e_rx_offset(rx_ring));
 			xdp.data_end = (void *)((u8 *)xdp.data + size);

--- a/drivers/net/ethernet/intel/iavf/iavf_txrx.c
+++ b/drivers/net/ethernet/intel/iavf/iavf_txrx.c
@@ -1698,6 +1698,7 @@ static int iavf_clean_rx_irq(struct iavf_ring *rx_ring, int budget)
 			if (rx_buffer) {
 				xdp.data = page_address(rx_buffer->page) +
 					   rx_buffer->page_offset;
+				xdp_set_data_meta_invalid(&xdp);
 				xdp.data_hard_start = (void *)((u8 *)xdp.data -
 						      iavf_rx_offset(rx_ring));
 				xdp.data_end = (void *)((u8 *)xdp.data + size);

--- a/drivers/vhost/net.c
+++ b/drivers/vhost/net.c
@@ -744,6 +744,7 @@ static int vhost_net_build_xdp(struct vhost_net_virtqueue *nvq,
 	xdp->data_hard_start = buf;
 	xdp->data = buf + pad;
 	xdp->data_end = xdp->data + len;
+	xdp_set_data_meta_invalid(xdp);
 	hdr->buflen = buflen;
 
 	--net->refcnt_bias;


### PR DESCRIPTION
Uninitialized xdp->data_meta can result in NULL pointer deference in
bpf_xdp_adjust_head(). Therefore, fix it by init it with
xdp_set_data_meta_invalid().

Signed-off-by: Menglong Dong <imagedong@tencent.com>