### PR TITLE
net/tcp: switch to GSO being always on

### DIFF
--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -281,7 +281,7 @@ int sysctl_tstamp_allow_data __read_mostly = 1;
 DEFINE_STATIC_KEY_FALSE(memalloc_socks_key);
 EXPORT_SYMBOL_GPL(memalloc_socks_key);
 
-int sysctl_forced_caps_enabled __read_mostly = 0;
+int sysctl_forced_caps_enabled __read_mostly = 1;
 EXPORT_SYMBOL(sysctl_forced_caps_enabled);
 
 /**


### PR DESCRIPTION
when open gso, tcp Write queues have less overhead, and make some app
run faster.

test of redis-benchmark like follow:

---
echo 1 > /proc/sys/net/core/forced_caps_enabled
get     hset    incr    sadd    set
2781766 737425  2210748 2160010 783656

---
echo 0 > /proc/sys/net/core/forced_caps_enabled
get     hset    incr    sadd    set
2728225 503815  2181630 2127274 507045

see, QPS of hset / set see a huge promote

Signed-off-by:mengensun<mengensun@tencent.com>
Reviewed-by: zhipingdu<zhipingdu@tencent.com>
Reviewed-by: frankjpliu<frankjpliu@tencent.com>