### PR TITLE
cgroupfs: support stat based on cpuacct

### DIFF
--- a/block/blk-cgroup.c
+++ b/block/blk-cgroup.c
@@ -827,8 +827,16 @@ static int blkcg_dkstats_show_comm(struct seq_file *sf, void *v, struct blkcg *b
 
 int blkcg_cgroupfs_dkstats_show(struct seq_file *m, void *v)
 {
-	struct blkcg *blkcg = css_to_blkcg(task_css(current, io_cgrp_id));
-	return blkcg_dkstats_show_comm(m, v, blkcg);
+	int ret;
+	struct cgroup_subsys_state *css;
+	struct blkcg *blkcg;
+
+	css = task_get_css(current, io_cgrp_id);
+	blkcg = css_to_blkcg(css);
+	ret = blkcg_dkstats_show_comm(m, v, blkcg);
+	css_put(css);
+
+	return ret;
 }
 
 static int blkcg_dkstats_show(struct seq_file *sf, void *v)

--- a/fs/cgroupfs/cgroupfs.h
+++ b/fs/cgroupfs/cgroupfs.h
@@ -6,10 +6,13 @@
 #define CGROUPFS_TYPE_UPTIME		(1 << 3)
 #define CGROUPFS_TYPE_LOADAVG		(1 << 4)
 #define CGROUPFS_TYPE_DKSTATS		(1 << 5)
-#define CGROUPFS_TYPE_VMSTAT		(1 << 6)
-#define CGROUPFS_TYPE_CPUDIR		(1 << 7)
-#define CGROUPFS_TYPE_NORMAL_DIR	(1 << 8)
-#define CGROUPFS_TYPE_AUTO_MOUNT	(1 << 9)
+#define CGROUPFS_TYPE_CPU_ONLINE	(1 << 6)
+#define CGROUPFS_TYPE_VMSTAT		(1 << 20)
+
+
+#define CGROUPFS_TYPE_CPUDIR		(1 << 21)
+#define CGROUPFS_TYPE_NORMAL_DIR	(1 << 22)
+#define CGROUPFS_TYPE_AUTO_MOUNT	(1 << 23)
 
 typedef struct cgroupfs_entry {
 	struct rb_root subdir;

--- a/fs/cgroupfs/mount.c
+++ b/fs/cgroupfs/mount.c
@@ -21,6 +21,7 @@ cgroupfs_entry_t *cgroupfs_root;
 cgroupfs_entry_t *sys_cpu;
 
 static int cgroufs_entry_num;
+extern int cgroupfs_mounted;
 
 static void cgroupfs_free_inode(struct inode *inode)
 {
@@ -273,6 +274,10 @@ static const struct file_operations cgroupfs_dir_operations = {
 	.iterate_shared		= cgroupfs_readdir,
 };
 
+static const struct dentry_operations cgroupfs_dentry_simple_ops = {
+	.d_delete       	= always_delete_dentry,
+};
+
 struct inode *cgroupfs_get_inode(cgroupfs_entry_t *en)
 {
 	struct inode *inode;
@@ -328,6 +333,15 @@ static int cgroupfs_new_cpu_dir(int fs_type, umode_t mode,
 	cgroupfs_entry_t *dir;
 	void *private;
 
+	if (!memcmp(name, "online", 7)) {
+		dir = cgroupfs_new_entry(cgroupfs_root->sb, "online", sys_cpu,
+					 CGROUPFS_TYPE_CPU_ONLINE, S_IFREG | 0644);
+		if (!dir)
+			return -1;
+		dir->e_dops = &cgroupfs_dentry_simple_ops;
+		return 0;
+	}
+
 	if (fs_type & CGROUPFS_TYPE_CPUDIR) {
 		i = start;
 		while (i < len) {
@@ -341,6 +355,7 @@ static int cgroupfs_new_cpu_dir(int fs_type, umode_t mode,
 	private = kmalloc(len + base_len + 1, GFP_KERNEL);
 	if (!private)
 		return -1;
+
 	dir = cgroupfs_new_entry(cgroupfs_root->sb, name,
 				sys_cpu, fs_type, mode);
 	if (!dir) {
@@ -478,11 +493,13 @@ static int cgroupfs_fill_super(struct super_block *sb, void *data, int silent)
 static struct dentry *cgroupfs_get_super(struct file_system_type *fst,
 	int flags, const char *devname, void *data)
 {
+	cgroupfs_mounted = 1;
 	return mount_single(fst, flags, data, cgroupfs_fill_super);
 }
 
 static void cgroupfs_kill_sb(struct super_block *sb)
 {
+	cgroupfs_mounted = 0;
 	kill_anon_super(sb);
 	cgroupfs_umount_remove_tree(cgroupfs_root);
 }

--- a/fs/cgroupfs/proc.c
+++ b/fs/cgroupfs/proc.c
@@ -17,7 +17,24 @@ extern int cpuacct_cgroupfs_uptime_show(struct seq_file *m, void *v);
 extern int cpuset_cgroupfs_loadavg_show(struct seq_file *m, void *v);
 extern int blkcg_cgroupfs_dkstats_show(struct seq_file *m, void *v);
 extern int mem_cgroupfs_vmstat_show(struct seq_file *m, void *v);
-extern int blkcg_cgroupfs_dkstats_show(struct seq_file *m, void *v);
+extern int cpu_get_max_cpus(struct task_struct *p);
+extern int cpuset_cgroupfs_get_cpu_count(void);
+
+static int cgroupfs_handle_online_cpu(struct seq_file *m, void *v)
+{
+	int cpu = cpu_get_max_cpus(current);
+	int cpu_set = cpuset_cgroupfs_get_cpu_count();
+	if (cpu > cpu_set)
+		cpu = cpu_set;
+	if (cpu > nr_cpu_ids)
+		cpu = nr_cpu_ids;
+	if (cpu == 1)
+		seq_printf(m, "0");
+	else
+		seq_printf(m, "0-%d", cpu - 1);
+	seq_putc(m, '\n');
+	return 0;
+}
 
 static int cgroup_fs_show(struct seq_file *m, void *v)
 {
@@ -37,6 +54,8 @@ static int cgroup_fs_show(struct seq_file *m, void *v)
 		return blkcg_cgroupfs_dkstats_show(m, v);
 	case CGROUPFS_TYPE_VMSTAT:
 		return mem_cgroupfs_vmstat_show(m, v);
+	case CGROUPFS_TYPE_CPU_ONLINE:
+		return cgroupfs_handle_online_cpu(m, v);
 	default:
 		break;
 	}

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7178,15 +7178,18 @@ int container_cpuquota_aware;
 int cpu_get_max_cpus(struct task_struct *p)
 {
 	int max_cpus = INT_MAX;
-	struct task_group *tg = task_group(p);
+	struct cgroup_subsys_state *css = task_get_css(p, cpu_cgrp_id);
+	struct task_group *tg = container_of(css, struct task_group, css);
 
 	if (!cpu_quota_aware_enabled(tg))
-		return max_cpus;
+		goto out;
 
 	if (tg->cfs_bandwidth.quota == RUNTIME_INF)
-		return max_cpus;
+		goto out;
 
 	max_cpus = DIV_ROUND_UP(tg->cfs_bandwidth.quota, tg->cfs_bandwidth.period);
+out:
+	css_put(css);
 
 	return max_cpus;
 }

--- a/kernel/sched/cpuacct.c
+++ b/kernel/sched/cpuacct.c
@@ -339,8 +339,24 @@ static int cpuacct_sli_max_show(struct seq_file *sf, void *v)
 
 int cpuacct_cgroupfs_uptime_show(struct seq_file *m, void *v)
 {
-	struct cpuacct *ca = task_ca(current);
-	return cpuacct_uptime_show_comm(m, v, ca);
+	int ret;
+	struct cgroup_subsys_state *css;
+	struct cpuacct *ca;
+
+	css = task_get_css(current, cpuacct_cgrp_id);
+	ca = css_ca(css);
+	ret = cpuacct_uptime_show_comm(m, v, ca);
+	css_put(css);
+
+	return ret;
+}
+
+int cpuacct_cgroupfs_cpu_usage(struct cgroup_subsys_state *css, int cpu, u64 *sys, u64 *user)
+{
+	struct cpuacct *ca = css_ca(css);
+	*user = cpuacct_cpuusage_read(ca, cpu, CPUACCT_STAT_USER);
+	*sys = cpuacct_cpuusage_read(ca, cpu, CPUACCT_STAT_SYSTEM);
+	return 0;
 }
 
 static int cpuacct_uptime_show(struct seq_file *sf, void *v)

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -311,6 +311,8 @@ int sendto_info_flag;
 int recvfrom_info_flag;
 int execve_info_flag;
 extern int container_cpuquota_aware;
+extern int cgroupfs_stat_show_cpuacct_info;
+int cgroupfs_mounted = 0;
 
 /* The default sysctl tables: */
 
@@ -372,6 +374,20 @@ static struct ctl_table kern_table[] = {
 		.data           = &container_cpuquota_aware,
 		.maxlen         = sizeof(unsigned int),
 		.mode           = 0644,
+		.proc_handler   = proc_dointvec,
+	},
+	{
+		.procname       = "cgroupfs_stat_show_cpuacct_info",
+		.data           = &cgroupfs_stat_show_cpuacct_info,
+		.maxlen         = sizeof(unsigned int),
+		.mode           = 0644,
+		.proc_handler   = proc_dointvec,
+	},
+	{
+		.procname       = "cgroupfs_mounted",
+		.data           = &cgroupfs_mounted,
+		.maxlen         = sizeof(unsigned int),
+		.mode           = 0444,
 		.proc_handler   = proc_dointvec,
 	},
 	{

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -5303,8 +5303,16 @@ static int mem_cgroup_meminfo_read_comm(struct seq_file *m, void *v, struct mem_
 
 int mem_cgroupfs_meminfo_show(struct seq_file *m, void *v)
 {
-	struct mem_cgroup *memcg = mem_cgroup_from_task(current);
-	return mem_cgroup_meminfo_read_comm(m, v, memcg);
+	int ret;
+	struct cgroup_subsys_state *css;
+	struct mem_cgroup *memcg;
+
+	css = task_get_css(current, memory_cgrp_id);
+	memcg = mem_cgroup_from_css(css);
+	ret = mem_cgroup_meminfo_read_comm(m, v, memcg);
+	css_put(css);
+
+	return ret;
 }
 
 static int mem_cgroup_meminfo_read(struct seq_file *m, void *v)
@@ -5474,8 +5482,16 @@ static int mem_cgroup_sli_show(struct seq_file *m, void *v)
 
 int mem_cgroupfs_vmstat_show(struct seq_file *m, void *v)
 {
-	struct mem_cgroup *memcg = mem_cgroup_from_task(current);
-	return mem_cgroup_vmstat_read_comm(m, v, memcg);
+	int ret;
+	struct cgroup_subsys_state *css;
+	struct mem_cgroup *memcg;
+
+	css = task_get_css(current, memory_cgrp_id);
+	memcg = mem_cgroup_from_css(css);
+	ret = mem_cgroup_vmstat_read_comm(m, v, memcg);
+	css_put(css);
+
+	return ret;
 }
 
 static int mem_cgroup_vmstat_read(struct seq_file *m, void *vv)


### PR DESCRIPTION
currently, /proc/stat displays cpu usage for real cpu,
add support to display cpu usage based on cpuacct,
online file on cgroupfs is changed to display cpu count
minimum of cpuset and cpuacct. sysctl
cgroupfs_stat_show_cpuacct_info is used to start this feature.

Signed-off-by: caelli <caelli@tencent.com>
Reviewed-by: Bin Lai <robinlai@tencent.com>