### PR TITLE
block: dont count passthrough req as inflight

### DIFF
--- a/block/blk-mq.c
+++ b/block/blk-mq.c
@@ -105,7 +105,9 @@ static bool blk_mq_check_inflight(struct blk_mq_hw_ctx *hctx,
 	/*
 	 * index[0] counts the specific partition that was asked for.
 	 */
-	if (!mi->part->partno || rq->part == mi->part)
+	if (rq->part && blk_do_io_stat(rq) &&
+			!(rq->rq_flags & RQF_FLUSH_SEQ) &&
+			(!mi->part->partno || rq->part == mi->part))
 		mi->inflight[0]++;
 
 	return true;
@@ -128,7 +130,9 @@ static bool blk_mq_check_inflight_rw(struct blk_mq_hw_ctx *hctx,
 {
 	struct mq_inflight *mi = priv;
 
-	if (rq->part == mi->part)
+	if (rq->part && blk_do_io_stat(rq) &&
+			!(rq->rq_flags & RQF_FLUSH_SEQ) &&
+			(!mi->part->partno || rq->part == mi->part))
 		mi->inflight[rq_data_dir(rq)]++;
 
 	return true;


### PR DESCRIPTION
upstream backport: b0d97557ebfc block: fix inflight statistics of part0
cause passthrough req count as inflight, and count as ioutil at reading
diskstats, but not at req completion.

Signed-off-by: samuelliao <samuelliao@tencent.com>