### PR TITLE
rue: open mbuf default and set default mbuf size to 8M

### DIFF
--- a/kernel/cgroup/cgroup.c
+++ b/kernel/cgroup/cgroup.c
@@ -182,7 +182,7 @@ static u16 cgrp_dfl_threaded_ss_mask;
 LIST_HEAD(cgroup_roots);
 static int cgroup_root_count;
 
-int sysctl_qos_mbuf_enable = 0;
+int sysctl_qos_mbuf_enable = 1;
 
 /* hierarchy ID allocation and mapping, protected by cgroup_mutex */
 static DEFINE_IDR(cgroup_hierarchy_idr);

--- a/kernel/cgroup/mbuf.c
+++ b/kernel/cgroup/mbuf.c
@@ -21,7 +21,7 @@
 /* Define max mbuf len is 8M, and min is 2M */
 #define MBUF_LEN_MAX (1 << 23)
 #define MBUF_LEN_MIN (1 << 21)
-#define MBUF_LEN_DEF MBUF_LEN_MIN
+#define MBUF_LEN_DEF MBUF_LEN_MAX
 
 #define MBUF_MSG_LEN_MAX 1024
 


### PR DESCRIPTION
Now, mbuf is disabled by default so it can not be used when
some Pods need it. For example, some process have a long sys
with no reason, if mbuf and sli is ready, key stack info may
be recorded. sli can be open during Pods lifecycle, buf mbuf needs
recreate cgroup so as to alloc mbuf memory for it. So, we open mbuf
default.

Default mbuf memory is 2M and supported 512 cgroups, each cgroup has 4K
memory, which is not enough in some case. So just adjust it to 8M.

Signed-off-by: bauerchen <bauerchen@tencent.com>