### PR TITLE
net: bpf: fix compile error in bpf_redirect_peer helper

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -2361,7 +2361,8 @@ out:
 
 /* Internal, non-exposed redirect flags. */
 enum {
-	BPF_F_NEIGH = (1ULL << 1),
+	BPF_F_NEIGH	= (1ULL << 1),
+	BPF_F_PEER	= (1ULL << 2),
 	BPF_F_NEXTHOP	= (1ULL << 3),
 #define BPF_F_REDIRECT_INTERNAL	(BPF_F_NEIGH | BPF_F_PEER | BPF_F_NEXTHOP)
 };


### PR DESCRIPTION
Some error happens while compiling bpf_redirect_peer helper, which
may be caused during code backport.

Fix it by add the missing BPF_F_PEER.

Signed-off-by: Menglong Dong <imagedong@tencent.com>