### PR TITLE
net: bpf: disable the usage of bpf_dispatcher for XDP

### DIFF
--- a/net/core/dev.c
+++ b/net/core/dev.c
@@ -8426,9 +8426,6 @@ static int dev_xdp_install(struct net_device *dev, bpf_op_t bpf_op,
 	xdp.prog = prog;
 
 	err = bpf_op(dev, &xdp);
-	if (!err && non_hw)
-		bpf_prog_change_xdp(prev_prog, prog);
-
 	if (prev_prog)
 		bpf_prog_put(prev_prog);
 


### PR DESCRIPTION
The usage of bpf_dispatcher for XDP caused kernel panic, and the reason
has not found. Therefore, disable it for now.

Signed-off-by: Menglong Dong <imagedong@tencent.com>