### PR TITLE
package: support repackage bpftool for tl2

### DIFF
--- a/package/arm/perf-tlinux.spec
+++ b/package/arm/perf-tlinux.spec
@@ -11,6 +11,9 @@
 %endif
 %endif
 
+%global build_env DESTDIR="%{buildroot}" prefix=%{_prefix} lib=%{_lib} PYTHON=%{__python3} INSTALL_ROOT=%{buildroot}
+%global bpftool_make make %{?_smp_mflags} -C tools/bpf/bpftool %{build_env} mandir=%{_mandir} bash_compdir=%{_sysconfdir}/bash_completion.d/
+
 Summary: Performance monitoring for the Linux kernel
 Group: Development/System
 Name: %{name}
@@ -52,6 +55,21 @@ Group: Development/Libraries
 The python-perf package contains a module that permits applications
 written in the Python programming language to use the interface
 to manipulate perf events.
+
+
+%package -n bpftool
+Summary: Inspection and simple manipulation of eBPF programs and maps
+License: GPLv2
+BuildRequires: llvm
+%if 0%{?rhel} == 7
+BuildRequires: python2-docutils
+%else
+BuildRequires: python3-docutils
+%endif
+%description -n bpftool
+This package contains the bpftool, which allows inspection and simple
+manipulation of eBPF programs and maps.
+
 
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
@@ -97,6 +115,9 @@ sed -i -e 's/CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION='$localversion'/' ${objd
 %{perf_make} all
 %{perf_make} man
 
+# bpftool
+%{bpftool_make}
+
 # install ######################################################################
 %install
 cd %{name}-%{version}
@@ -107,6 +128,9 @@ cd %{name}-%{version}
 
 # perf man pages (note: implicit rpm magic compresses them later)
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install-man
+
+%{bpftool_make} install doc-install
+/usr/lib/rpm/brp-compress
 
 %pre
 # pre #########################################################################
@@ -146,6 +170,12 @@ fi
 %files -n python-perf
 %defattr(-,root,root)
 %{python_sitearch}
+
+%files -n bpftool
+%defattr(-,root,root)
+%{_sbindir}/bpftool
+%{_sysconfdir}/bash_completion.d/bpftool
+%{_mandir}/man8/bpftool*.gz
 
 
 # changelog  ###################################################################

--- a/package/default/perf-tools-tlinux.spec
+++ b/package/default/perf-tools-tlinux.spec
@@ -11,6 +11,9 @@
 %endif
 %endif
 
+%global build_env DESTDIR="%{buildroot}" prefix=%{_prefix} lib=%{_lib} PYTHON=%{__python3} INSTALL_ROOT=%{buildroot}
+%global bpftool_make make %{?_smp_mflags} -C tools/bpf/bpftool %{build_env} mandir=%{_mandir} bash_compdir=%{_sysconfdir}/bash_completion.d/
+
 # Architectures we build tools/cpupower on
 %define cpupowerarchs x86_64 aarch64
 
@@ -90,6 +93,19 @@ License: GPLv2
 This package contains the libraries built from the tools/ directory
 from the kernel source.
 
+%package -n bpftool
+Summary: Inspection and simple manipulation of eBPF programs and maps
+License: GPLv2
+BuildRequires: llvm
+%if 0%{?rhel} == 7
+BuildRequires: python2-docutils
+%else
+BuildRequires: python3-docutils
+%endif
+%description -n bpftool
+This package contains the bpftool, which allows inspection and simple
+manipulation of eBPF programs and maps.
+
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
 
@@ -158,6 +174,8 @@ pushd tools
 make tmon
 popd
 
+%{bpftool_make}
+
 # install ######################################################################
 %install
 cd %{name}-%{version}
@@ -198,6 +216,9 @@ pushd tools/thermal/tmon
 make INSTALL_ROOT=%{buildroot} install
 popd
 %endif
+
+%{bpftool_make} install doc-install
+/usr/lib/rpm/brp-compress
 
 %pre
 # pre #########################################################################
@@ -265,6 +286,12 @@ fi
 %{_libdir}/libcpupower.so.0
 %{_libdir}/libcpupower.so.0.0.1
 %endif
+
+%files -n bpftool
+%defattr(-,root,root)
+%{_sbindir}/bpftool
+%{_sysconfdir}/bash_completion.d/bpftool
+%{_mandir}/man8/bpftool*.gz
 
 # changelog  ###################################################################
 %changelog


### PR DESCRIPTION
tl2 release system using repackage trick instead of full tl2 env to build kernel and other packages from scratch.

Update the perf tools spec to support build bpftool with perf and kernel tools.

Signed-off-by: Haisu Wang <haisuwang@tencent.com>