### PR TITLE
generate-rpm.sh: unify package script

### DIFF
--- a/package/arm/generate-rpms.sh
+++ b/package/arm/generate-rpms.sh
@@ -23,7 +23,7 @@ nosign_suffix=""
 build_src_only=0
 strip_sign_token=0
 nosign_suffix=""
-raw_tagged_name=""
+tagged_name=""
 # to control wheter to build rpm for xen domU
 isXenU=""
 build_perf=""
@@ -70,22 +70,15 @@ get_kernel_version()
 get_tlinux_name()
 {
 	if [ -n "$tag_name" ]; then
-		raw_tagged_name="$tag_name"
+		tagged_name="$tag_name"
 	else
-		raw_tagged_name=`git describe --tags`
+		tagged_name=`git describe --tags`
 	fi
 	
-	if [ -z "${raw_tagged_name}" ];then
+	if [ -z "${tagged_name}" ];then
 		echo "Error:Can't get kernel version from git tree."
 		exit 1
 	fi
-
-        if [[ $raw_tagged_name != arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for arm64"
-                exit 1
-	fi
-
-	tagged_name=${raw_tagged_name#arm64-}
 
 	echo "${tagged_name}" | grep 'kvm_guest'
 	if [ $? -eq 0 ]; then
@@ -285,7 +278,7 @@ if test -e ${build_srcdir}/${kernel_full_name}; then
 fi
 
 #tagged_name is a confirmed tag name and will be used for final source.
-git archive --format=tar --prefix=${kernel_full_name}/ ${raw_tagged_name} | (cd ${build_srcdir} && tar xf  -)
+git archive --format=tar --prefix="${kernel_full_name}"/ "${tagged_name}" | (cd "${build_srcdir}" && tar xf  -)
 if [ $? -ne 0 ];then
 	echo "Error:can't prepare $kernel_full_name source with git archive!"
 	exit 1

--- a/package/arm/repackage/generate-rpms.sh
+++ b/package/arm/repackage/generate-rpms.sh
@@ -55,17 +55,7 @@ usage()
 
 get_kernel_version()
 {
-	local tagged_name
-	raw_tagged_name=$tag_name
-
-	if [[ $raw_tagged_name != arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for arm64"
-                exit 1
-        fi  
-
-	tagged_name=${raw_tagged_name#arm64-}
-
-	kernel_version=`echo $tagged_name|cut -d- -f1`
+	kernel_version=`echo $tag_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
 	#echo "kernel version: $kernel_version"
 	echo "kernel version: ${kernel_version}"
@@ -74,23 +64,15 @@ get_kernel_version()
 get_tlinux_name()
 {
 	if [ -n "$tag_name" ]; then
-		raw_tagged_name="$tag_name"
+		tagged_name="$tag_name"
 	else
-		raw_tagged_name=`git describe --tags`
+		tagged_name=`git describe --tags`
 	fi
 	
-	if [ -z "${raw_tagged_name}" ];then
+	if [ -z "${tagged_name}" ];then
 		echo "Error:Can't get kernel version from git tree."
 		exit 1
 	fi
-
-	if [[ $raw_tagged_name != arm64-* ]]; then
-                echo "$raw_tagged_name not valid tag name for arm64"
-                exit 1
-        fi  
-
-	tagged_name=${raw_tagged_name#arm64-}
-
 
 	echo "${tagged_name}" | grep 'kvm_guest'
 	if [ $? -eq 0 ]; then

--- a/package/default/generate-rpms.sh
+++ b/package/default/generate-rpms.sh
@@ -20,7 +20,7 @@ make_jobs=""
 nosign_suffix=""
 build_src_only=0
 strip_sign_token=0
-raw_tagged_name=""
+tagged_name=""
 kasan=0
 # to control wheter to build rpm for xen domU
 isXenU=""
@@ -71,22 +71,15 @@ get_kernel_version()
 get_tlinux_name()
 {
 	if [ -n "$tag_name" ]; then
-		raw_tagged_name="$tag_name"
+		tagged_name="$tag_name"
 	else
-		raw_tagged_name=`git describe --tags`
+		tagged_name=`git describe --tags`
 	fi
 	
-	if [ -z "${raw_tagged_name}" ];then
+	if [ -z "${tagged_name}" ];then
 		echo "Error:Can't get kernel version from git tree."
 		exit 1
 	fi
-
-	if [[ $raw_tagged_name != x86-* ]]; then
-		echo "$raw_tagged_name not valid tag name for x86"
-		exit 11
-	fi
-
-	tagged_name=${raw_tagged_name#x86-}
 
 	echo "${tagged_name}" | grep 'kasan'
 	if [ $?  -eq 0 ]; then
@@ -241,7 +234,7 @@ if test -e ${build_srcdir}/${kernel_full_name}; then
 fi
 
 #tagged_name is a confirmed tag name and will be used for final source.
-git archive --format=tar --prefix=${kernel_full_name}/ ${raw_tagged_name} | (cd ${build_srcdir} && tar xf  -)
+git archive --format=tar --prefix=${kernel_full_name}/ ${tagged_name} | (cd ${build_srcdir} && tar xf  -)
 if [ $? -ne 0 ];then
 	echo "Error:can't prepare $kernel_full_name source with git archive!"
 	exit 1

--- a/package/default/repackage/generate-rpms.sh
+++ b/package/default/repackage/generate-rpms.sh
@@ -30,17 +30,7 @@ kernel_default_types=(default)
 
 get_kernel_version()
 {
-	local tagged_name
-	raw_tagged_name=$tag_name
-
-	if [[ $raw_tagged_name != x86-* ]]; then
-                echo "$raw_tagged_name not valid tag name for x86"
-                exit 1
-        fi  
-
-	tagged_name=${raw_tagged_name#x86-}
-
-	kernel_version=`echo $tagged_name|cut -d- -f1`
+	kernel_version=`echo $tag_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
 	#echo "kernel version: $kernel_version"
 	echo "kernel version: ${kernel_version}"
@@ -49,22 +39,15 @@ get_kernel_version()
 get_tlinux_name()
 {
 	if [ -n "$tag_name" ]; then
-		raw_tagged_name="$tag_name"
+		tagged_name="$tag_name"
 	else
-		raw_tagged_name=`git describe --tags`
+		tagged_name=`git describe --tags`
 	fi
 	
-	if [ -z "${raw_tagged_name}" ];then
+	if [ -z "${tagged_name}" ];then
 		echo "Error:Can't get kernel version from git tree."
 		exit 1
 	fi
-
-	if [[ $raw_tagged_name != x86-* ]]; then
-		echo "$raw_tagged_name not valid tag name for x86"
-		exit 1
-	fi  
-
-	tagged_name=${raw_tagged_name#x86-}
 
 	#if [ "${tagged_name#*-*-*}" != ${tagged_name} ];then
 		#echo "Error: bad tag name:$tagged_name."


### PR DESCRIPTION
Modify generate-rpm.sh so that x86/arm can use the same tag.

Signed-off-by: Yushan Zhou <katrinzhou@tencent.com>