### PR TITLE
package: support tag startswith x86

### DIFF
--- a/package/arm/generate-rpms.sh
+++ b/package/arm/generate-rpms.sh
@@ -82,6 +82,7 @@ get_tlinux_name()
 		exit 1
 	fi
 
+	tagged_name=${tagged_name#arm64-}
 	echo "${tagged_name}" | grep 'kvm_guest'
 	if [ $? -eq 0 ]; then
 		echo "start kvm guest build"

--- a/package/arm/repackage/generate-rpms.sh
+++ b/package/arm/repackage/generate-rpms.sh
@@ -55,7 +55,8 @@ usage()
 
 get_kernel_version()
 {
-	kernel_version=`echo $tag_name|cut -d- -f1`
+	tagged_name=${tag_name#arm64-}
+	kernel_version=`echo $tagged_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
 	#echo "kernel version: $kernel_version"
 	echo "kernel version: ${kernel_version}"
@@ -74,6 +75,7 @@ get_tlinux_name()
 		exit 1
 	fi
 
+	tagged_name=${tagged_name#arm64-}
 	echo "${tagged_name}" | grep 'kvm_guest'
 	if [ $? -eq 0 ]; then
 		echo "start kvm guest build"

--- a/package/default/generate-rpms.sh
+++ b/package/default/generate-rpms.sh
@@ -83,6 +83,7 @@ get_tlinux_name()
 		exit 1
 	fi
 
+	tagged_name=${tagged_name#x86-}
 	echo "${tagged_name}" | grep 'kasan'
 	if [ $?  -eq 0 ]; then
 		kasan=1
@@ -297,7 +298,7 @@ if test -e ${build_srcdir}/${kernel_full_name}; then
 fi
 
 #tagged_name is a confirmed tag name and will be used for final source.
-git archive --format=tar --prefix=${kernel_full_name}/ ${tagged_name} | (cd ${build_srcdir} && tar xf  -)
+git archive --format=tar --prefix=${kernel_full_name}/ ${tag_name} | (cd ${build_srcdir} && tar xf  -)
 if [ $? -ne 0 ];then
 	echo "Error:can't prepare $kernel_full_name source with git archive!"
 	exit 1

--- a/package/default/repackage/generate-rpms.sh
+++ b/package/default/repackage/generate-rpms.sh
@@ -30,7 +30,8 @@ kernel_default_types=(default)
 
 get_kernel_version()
 {
-	kernel_version=`echo $tag_name|cut -d- -f1`
+	tagged_name=${tag_name#x86-}
+	kernel_version=`echo $tagged_name|cut -d- -f1`
 	#kernel_version=${kernel_version}-1
 	#echo "kernel version: $kernel_version"
 	echo "kernel version: ${kernel_version}"
@@ -49,6 +50,7 @@ get_tlinux_name()
 		exit 1
 	fi
 
+	tagged_name=${tagged_name#x86-}
 	#if [ "${tagged_name#*-*-*}" != ${tagged_name} ];then
 		#echo "Error: bad tag name:$tagged_name."
 		#exit 1


### PR DESCRIPTION
Tmanager generates tag to build kernel when branch specified. The tag starts with x86, which leads to the build process failing to parse the tag.
Modify the generate-rpms.sh to support building with "x86-*" tags.

Signed-off-by: Yushan Zhou <katrinzhou@tencent.com>