### PR TITLE
Fix the kernel perf package include files

### DIFF
--- a/package/arm/kernel-tlinux.spec
+++ b/package/arm/kernel-tlinux.spec
@@ -205,7 +205,7 @@ do
 #  dealing with files under lib/modules
     make -j16  -C ${objdir} RPM_BUILD_MODULE=y modules > /dev/null
 
-    %global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix}
+    %global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix} lib=%{_lib}
     %if %{with_perf}
     # perf
     %{perf_make} all
@@ -457,6 +457,7 @@ do
     %if %{with_perf}
     # perf tool binary and supporting scripts/binaries
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+    rm -f %{buildroot}%{_bindir}/trace
 
     # perf-python extension
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install-python_ext
@@ -574,15 +575,18 @@ echo -e "Remove \"%{tagged_name}%{?dist}\" Done."
 %if %{with_perf}
 %files -n perf
 %defattr(-,root,root)
-%{_bindir}/*
-/usr/lib64/*
-/usr/lib/traceevent/plugins/*.so
-/usr/lib/perf/examples/bpf/*
-/usr/lib/perf/include/bpf/*
-/usr/share/*
+%{_bindir}/perf
+%{_sysconfdir}/bash_completion.d/perf
+%dir %{_prefix}/lib/perf
+%{_prefix}/lib/perf/*
+%dir %{_libdir}/traceevent/
+%{_libdir}/traceevent/*
+%{_libdir}/libperf-jvmti.so
 %dir %{_libexecdir}/perf-core
 %{_libexecdir}/perf-core/*
-%{_sysconfdir}/bash_completion.d/perf
+%{_datadir}/perf-core/*
+%{_docdir}/perf-tip/tips.txt
+%{_mandir}/man[1-8]/perf*
 
 %files -n python-perf
 %defattr(-,root,root)

--- a/package/arm/kernel-tlinux.spec
+++ b/package/arm/kernel-tlinux.spec
@@ -457,6 +457,8 @@ do
     %if %{with_perf}
     # perf tool binary and supporting scripts/binaries
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+    mkdir -p %{buildroot}%{_libdir}
+    touch %{buildroot}%{_libdir}/libperf-jvmti.so
     rm -f %{buildroot}%{_bindir}/trace
 
     # perf-python extension

--- a/package/arm/perf-tlinux.spec
+++ b/package/arm/perf-tlinux.spec
@@ -117,6 +117,8 @@ fi
 %install
 cd %{name}-%{version}
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+mkdir -p %{buildroot}%{_libdir}
+touch %{buildroot}%{_libdir}/libperf-jvmti.so
 rm -rf %{buildroot}%{_bindir}/trace
 
 # perf-python extension

--- a/package/arm/perf-tlinux.spec
+++ b/package/arm/perf-tlinux.spec
@@ -11,6 +11,10 @@
 %endif
 %endif
 
+%if 0%{?rhel} == 8
+%global __python %{__python2}
+%endif
+
 %global build_env DESTDIR="%{buildroot}" prefix=%{_prefix} lib=%{_lib} PYTHON=%{__python3} INSTALL_ROOT=%{buildroot}
 %global bpftool_make make %{?_smp_mflags} -C tools/bpf/bpftool %{build_env} mandir=%{_mandir} bash_compdir=%{_sysconfdir}/bash_completion.d/
 
@@ -29,9 +33,14 @@ ExclusiveArch:  aarch64
 Distribution: Tencent Linux
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-build
 BuildRequires: wget bc module-init-tools curl
-BuildRequires: elfutils-devel zlib-devel binutils-devel newt-devel python-devel perl(ExtUtils::Embed) bison flex
+BuildRequires: elfutils-devel zlib-devel binutils-devel newt-devel perl(ExtUtils::Embed) bison flex
 BuildRequires: xmlto asciidoc
 BuildRequires: audit-libs-devel
+%if 0%{?rhel} == 8
+BuildRequires: python2-devel
+%else
+BuildRequires: python-devel
+%endif
 %ifnarch s390 s390x
 BuildRequires: numactl-devel
 %endif
@@ -96,7 +105,7 @@ if [ $num_processor -gt 8 ]; then
     num_processor=8
 fi
 
-%global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix}
+%global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix} lib=%{_lib}
 # perf
 %{perf_make} all
 %{perf_make} man
@@ -108,6 +117,7 @@ fi
 %install
 cd %{name}-%{version}
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+rm -rf %{buildroot}%{_bindir}/trace
 
 # perf-python extension
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install-python_ext
@@ -142,16 +152,17 @@ fi
 %files
 %defattr(-,root,root)
 %{_bindir}/perf
+%{_sysconfdir}/bash_completion.d/perf
+%dir %{_prefix}/lib/perf
+%{_prefix}/lib/perf/*
+%dir %{_libdir}/traceevent/
+%{_libdir}/traceevent/*
+%{_libdir}/libperf-jvmti.so
 %dir %{_libexecdir}/perf-core
 %{_libexecdir}/perf-core/*
+%{_datadir}/perf-core/*
+%{_docdir}/perf-tip/tips.txt
 %{_mandir}/man[1-8]/perf*
-%{_sysconfdir}/bash_completion.d/perf
-/usr/bin/trace
-/usr/lib/traceevent/plugins/*
-/usr/lib/perf
-/usr/share/doc/*
-/usr/share/perf-core/strace/groups
-/usr/share/perf-core/strace/groups
 
 %files -n python-perf
 %defattr(-,root,root)

--- a/package/default/kernel-tlinux.spec
+++ b/package/default/kernel-tlinux.spec
@@ -271,7 +271,7 @@ do
     # cpupower
     # make sure version-gen.sh is executable.
     chmod +x tools/power/cpupower/utils/version-gen.sh
-    make %{?_smp_mflags} -C tools/power/cpupower CPUFREQ_BENCH=false
+    make %{?_smp_mflags} -C tools/power/cpupower bash_completion_dir=%{_sysconfdir}/bash_completion.d/ CPUFREQ_BENCH=false
     %ifarch x86_64
 	pushd tools/power/cpupower/debug/x86_64
 	make %{?_smp_mflags} centrino-decode powernow-k8-decode
@@ -547,7 +547,7 @@ do
 
     %if %{with_tools}
     %ifarch %{cpupowerarchs}
-    make -C tools/power/cpupower DESTDIR=$RPM_BUILD_ROOT libdir=%{_libdir} mandir=%{_mandir} CPUFREQ_BENCH=false install
+    make -C tools/power/cpupower DESTDIR=$RPM_BUILD_ROOT libdir=%{_libdir} mandir=%{_mandir} bash_completion_dir=%{_sysconfdir}/bash_completion.d/ CPUFREQ_BENCH=false install
     rm -f %{buildroot}%{_libdir}/*.{a,la}
     %find_lang cpupower
     mv cpupower.lang ../
@@ -727,12 +727,13 @@ echo -e "Remove \"%{tagged_name}%{?dist}\" Done."
 %endif
 %endif
 %{_bindir}/tmon
+%{_sysconfdir}/bash_completion.d/cpupower
+%{_oldincludedir}/cpu*.h
 
 %ifarch %{cpupowerarchs}
 %files -n kernel-tools-libs
 %defattr(-,root,root)
-%{_libdir}/libcpupower.so.0
-%{_libdir}/libcpupower.so.0.0.1
+%{_libdir}/libcpupower.so*
 %endif
 %endif # with_tools
 

--- a/package/default/kernel-tlinux.spec
+++ b/package/default/kernel-tlinux.spec
@@ -536,6 +536,8 @@ do
     %if %{with_perf}
     # perf tool binary and supporting scripts/binaries
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+    mkdir -p %{buildroot}%{_libdir}
+    touch %{buildroot}%{_libdir}/libperf-jvmti.so
     rm -f %{buildroot}%{_bindir}/trace
 
     # perf-python extension

--- a/package/default/kernel-tlinux.spec
+++ b/package/default/kernel-tlinux.spec
@@ -259,7 +259,7 @@ do
 #  dealing with files under lib/modules
     make -C ${objdir} RPM_BUILD_MODULE=y modules
 
-    %global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix}
+    %global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix} lib=%{_lib}
     %if %{with_perf}
     # perf
     %{perf_make} all
@@ -536,6 +536,7 @@ do
     %if %{with_perf}
     # perf tool binary and supporting scripts/binaries
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+    rm -f %{buildroot}%{_bindir}/trace
 
     # perf-python extension
     %{perf_make} DESTDIR=$RPM_BUILD_ROOT install-python_ext
@@ -680,13 +681,18 @@ echo -e "Remove \"%{tagged_name}%{?dist}\" Done."
 %if %{with_perf}
 %files -n perf
 %defattr(-,root,root)
-%{_bindir}/*
-/usr/lib64/*
-/usr/lib/perf/*
-/usr/share/*
+%{_bindir}/perf
+%{_sysconfdir}/bash_completion.d/perf
+%dir %{_prefix}/lib/perf
+%{_prefix}/lib/perf/*
+%dir %{_libdir}/traceevent/
+%{_libdir}/traceevent/*
+%{_libdir}/libperf-jvmti.so
 %dir %{_libexecdir}/perf-core
 %{_libexecdir}/perf-core/*
-%{_sysconfdir}/bash_completion.d/perf
+%{_datadir}/perf-core/*
+%{_docdir}/perf-tip/tips.txt
+%{_mandir}/man[1-8]/perf*
 
 %files -n python-perf
 %defattr(-,root,root)

--- a/package/default/perf-tools-tlinux.spec
+++ b/package/default/perf-tools-tlinux.spec
@@ -150,7 +150,7 @@ fi
 # cpupower
 # make sure version-gen.sh is executable.
 chmod +x tools/power/cpupower/utils/version-gen.sh
-make %{?_smp_mflags} -C tools/power/cpupower CPUFREQ_BENCH=false
+make %{?_smp_mflags} -C tools/power/cpupower bash_completion_dir=%{_sysconfdir}/bash_completion.d/ CPUFREQ_BENCH=false
 %ifarch x86_64
 	pushd tools/power/cpupower/debug/x86_64
 	make %{?_smp_mflags} centrino-decode powernow-k8-decode
@@ -185,7 +185,7 @@ rm -f %{buildroot}%{_bindir}/trace
 
 # kernel tools
 %ifarch %{cpupowerarchs}
-make -C tools/power/cpupower DESTDIR=$RPM_BUILD_ROOT libdir=%{_libdir} mandir=%{_mandir} CPUFREQ_BENCH=false install
+make -C tools/power/cpupower DESTDIR=$RPM_BUILD_ROOT libdir=%{_libdir} mandir=%{_mandir} bash_completion_dir=%{_sysconfdir}/bash_completion.d/ CPUFREQ_BENCH=false install
 rm -f %{buildroot}%{_libdir}/*.{a,la}
 %find_lang cpupower
 mv cpupower.lang ../
@@ -276,12 +276,13 @@ fi
 %endif
 %endif
 %{_bindir}/tmon
+%{_sysconfdir}/bash_completion.d/cpupower
+%{_oldincludedir}/cpu*.h
 
 %ifarch %{cpupowerarchs}
 %files -n kernel-tools-libs
 %defattr(-,root,root)
-%{_libdir}/libcpupower.so.0
-%{_libdir}/libcpupower.so.0.0.1
+%{_libdir}/libcpupower.so*
 %endif
 
 %files -n bpftool

--- a/package/default/perf-tools-tlinux.spec
+++ b/package/default/perf-tools-tlinux.spec
@@ -175,6 +175,8 @@ popd
 %install
 cd %{name}-%{version}
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+mkdir -p %{buildroot}%{_libdir}
+touch %{buildroot}%{_libdir}/libperf-jvmti.so
 rm -f %{buildroot}%{_bindir}/trace
 
 # perf-python extension

--- a/package/default/perf-tools-tlinux.spec
+++ b/package/default/perf-tools-tlinux.spec
@@ -11,6 +11,10 @@
 %endif
 %endif
 
+%if 0%{?rhel} == 8
+%global __python %{__python2}
+%endif
+
 %global build_env DESTDIR="%{buildroot}" prefix=%{_prefix} lib=%{_lib} PYTHON=%{__python3} INSTALL_ROOT=%{buildroot}
 %global bpftool_make make %{?_smp_mflags} -C tools/bpf/bpftool %{build_env} mandir=%{_mandir} bash_compdir=%{_sysconfdir}/bash_completion.d/
 
@@ -35,7 +39,12 @@ ExclusiveArch:  x86_64
 Distribution: Tencent Linux
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-build
 BuildRequires: wget bc module-init-tools curl
-BuildRequires: elfutils-devel zlib-devel binutils-devel newt-devel python-devel perl(ExtUtils::Embed) bison flex
+BuildRequires: elfutils-devel zlib-devel binutils-devel newt-devel perl(ExtUtils::Embed) bison flex
+%if 0%{?rhel} == 8
+BuildRequires: python2-devel
+%else
+BuildRequires: python-devel
+%endif
 BuildRequires: xmlto asciidoc
 BuildRequires: audit-libs-devel
 %ifnarch s390 s390x
@@ -131,7 +140,7 @@ if [ $num_processor -gt 8 ]; then
     num_processor=8
 fi
 
-%global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix}
+%global perf_make make %{?_smp_mflags} -C tools/perf -s V=1 WERROR=0 NO_LIBUNWIND=1 HAVE_CPLUS_DEMANGLE=1 NO_GTK2=1 NO_STRLCPY=1 prefix=%{_prefix} lib=%{_lib}
 # perf
 %{perf_make} all
 %{perf_make} man
@@ -166,6 +175,7 @@ popd
 %install
 cd %{name}-%{version}
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install
+rm -f %{buildroot}%{_bindir}/trace
 
 # perf-python extension
 %{perf_make} DESTDIR=$RPM_BUILD_ROOT install-python_ext
@@ -230,16 +240,17 @@ fi
 %files
 %defattr(-,root,root)
 %{_bindir}/perf
+%{_sysconfdir}/bash_completion.d/perf
+%dir %{_prefix}/lib/perf
+%{_prefix}/lib/perf/*
+%dir %{_libdir}/traceevent/
+%{_libdir}/traceevent/*
+%{_libdir}/libperf-jvmti.so
 %dir %{_libexecdir}/perf-core
 %{_libexecdir}/perf-core/*
+%{_datadir}/perf-core/*
+%{_docdir}/perf-tip/tips.txt
 %{_mandir}/man[1-8]/perf*
-%{_sysconfdir}/bash_completion.d/perf
-/usr/bin/trace
-/usr/bin/perf*
-/usr/lib64/*
-/usr/share/*
-/usr/lib/perf/*
-/usr/include/*
 
 %files -n python-perf
 %defattr(-,root,root)


### PR DESCRIPTION
The perf package include too many duplicated files of bpftool and kernel-tools. Remove/change to the corresponding packages.