### PR TITLE
sli: fix the compiling error caused by memory access out of range

### DIFF
--- a/kernel/cgroup/sli.c
+++ b/kernel/cgroup/sli.c
@@ -16,7 +16,7 @@
 #define MAX_STACK_TRACE_DEPTH	64
 
 struct member_offset {
-	char member[LINE_SIZE];
+	char *member;
 	int  offset;
 };
 


### PR DESCRIPTION
The member of member_offset structure should be char pointer and not an array, otherwise it could result in
memlat_member_offset[i].member always be true when we iterate the array. The ARM-GCC can find it and report the error.

Signed-off-by: Bin Lai <robinlai@tencent.com>
Reviewed-by: Munger Jiang <mungerjiang@tencent.com>